### PR TITLE
feat: add admin support portal

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -87,6 +87,25 @@ model Session {
   @@map("sessions")
 }
 
+enum AdminLevel {
+  support
+  super_admin
+
+  @@map("admin_level")
+}
+
+model AdminUser {
+  id           String      @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  name         String
+  email        String      @unique
+  passwordHash String      @map("passwordhash")
+  createdAt    DateTime    @default(now()) @map("createdat") @db.Timestamptz(6)
+  updatedAt    DateTime    @default(now()) @updatedAt @map("updatedat") @db.Timestamptz(6)
+  adminLevel   AdminLevel  @default(support) @map("admin_level")
+
+  @@map("admin_users")
+}
+
 /* ===========================
    Billing/Stripe
    =========================== */

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -9,9 +9,11 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-/* ===========================
-   Core auth/session
-   =========================== */
+/**
+ * ===========================
+ * Core auth/session
+ * ===========================
+ */
 
 model VerificationToken {
   identifier String
@@ -26,16 +28,18 @@ model VerificationToken {
 }
 
 model User {
-  id            String         @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  id            String      @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   name          String?
-  email         String         @unique
-  emailVerified DateTime?      @map("emailverified") @db.Timestamptz(6)
+  email         String      @unique
+  emailVerified DateTime?   @map("emailverified") @db.Timestamptz(6)
   image         String?
-  businessName  String?        @map("businessname")
-  phoneNumber   String?        @map("phonenumber")
-  passwordHash  String?        @map("passwordhash")
-  createdAt     DateTime       @default(now()) @map("createdat") @db.Timestamptz(6)
-  updatedAt     DateTime       @default(now()) @updatedAt @map("updatedat") @db.Timestamptz(6)
+  businessName  String?     @map("businessname")
+  phoneNumber   String?     @map("phonenumber")
+  passwordHash  String?     @map("passwordhash")
+  accountType   String      @default("customer") @map("accounttype")
+  adminLevel    AdminLevel? @map("admin_level")
+  createdAt     DateTime    @default(now()) @map("createdat") @db.Timestamptz(6)
+  updatedAt     DateTime    @default(now()) @updatedAt @map("updatedat") @db.Timestamptz(6)
 
   accounts      Account[]
   customer      Customer?
@@ -94,21 +98,11 @@ enum AdminLevel {
   @@map("admin_level")
 }
 
-model AdminUser {
-  id           String      @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  name         String
-  email        String      @unique
-  passwordHash String      @map("passwordhash")
-  createdAt    DateTime    @default(now()) @map("createdat") @db.Timestamptz(6)
-  updatedAt    DateTime    @default(now()) @updatedAt @map("updatedat") @db.Timestamptz(6)
-  adminLevel   AdminLevel  @default(support) @map("admin_level")
-
-  @@map("admin_users")
-}
-
-/* ===========================
-   Billing/Stripe
-   =========================== */
+/**
+ * ===========================
+ * Billing/Stripe
+ * ===========================
+ */
 
 model Customer {
   id               String   @id @db.Uuid
@@ -162,27 +156,27 @@ model StripeProduct {
 }
 
 model StripePrice {
-  id                String        @id
+  id                String   @id
   object            String?
-  active            Boolean       @default(true)
-  billingScheme     String?       @map("billing_scheme")
-  currency          String        @db.Char(3)
-  customUnitAmount  Json?         @map("custom_unit_amount")
-  livemode          Boolean       @default(false)
-  lookupKey         String?       @map("lookup_key")
-  metadata          Json          @default("{}")
+  active            Boolean  @default(true)
+  billingScheme     String?  @map("billing_scheme")
+  currency          String   @db.Char(3)
+  customUnitAmount  Json?    @map("custom_unit_amount")
+  livemode          Boolean  @default(false)
+  lookupKey         String?  @map("lookup_key")
+  metadata          Json     @default("{}")
   nickname          String?
   product           String
   recurring         Json?
-  taxBehavior       String?       @map("tax_behavior")
-  tiersMode         String?       @map("tiers_mode")
-  transformQuantity Json?         @map("transform_quantity")
+  taxBehavior       String?  @map("tax_behavior")
+  tiersMode         String?  @map("tiers_mode")
+  transformQuantity Json?    @map("transform_quantity")
   type              String
-  unitAmount        BigInt?       @map("unit_amount")
-  unitAmountDecimal String?       @map("unit_amount_decimal")
-  created           DateTime      @db.Timestamptz(6)
-  updated           DateTime      @default(now()) @db.Timestamptz(6)
-  data              Json          @default("{}")
+  unitAmount        BigInt?  @map("unit_amount")
+  unitAmountDecimal String?  @map("unit_amount_decimal")
+  created           DateTime @db.Timestamptz(6)
+  updated           DateTime @default(now()) @db.Timestamptz(6)
+  data              Json     @default("{}")
 
   productRelation StripeProduct @relation(fields: [product], references: [id], onDelete: Cascade)
 
@@ -213,22 +207,22 @@ model StripeWebhookEvent {
 }
 
 model Subscription {
-  id                 String   @id
+  id                 String    @id
   object             String?
-  userId             String   @map("user_id") @db.Uuid
+  userId             String    @map("user_id") @db.Uuid
   status             String
-  currentPeriodStart DateTime @map("current_period_start") @db.Timestamptz(6)
-  currentPeriodEnd   DateTime @map("current_period_end") @db.Timestamptz(6)
-  cancelAtPeriodEnd  Boolean  @map("cancel_at_period_end") @default(false)
+  currentPeriodStart DateTime  @map("current_period_start") @db.Timestamptz(6)
+  currentPeriodEnd   DateTime  @map("current_period_end") @db.Timestamptz(6)
+  cancelAtPeriodEnd  Boolean   @default(false) @map("cancel_at_period_end")
   cancelAt           DateTime? @map("cancel_at") @db.Timestamptz(6)
   canceledAt         DateTime? @map("canceled_at") @db.Timestamptz(6)
   trialStart         DateTime? @map("trial_start") @db.Timestamptz(6)
   trialEnd           DateTime? @map("trial_end") @db.Timestamptz(6)
-  metadata           Json     @default("{}")
-  created            DateTime @db.Timestamptz(6)
-  updated            DateTime @default(now()) @db.Timestamptz(6)
-  livemode           Boolean  @default(false)
-  data               Json     @default("{}")
+  metadata           Json      @default("{}")
+  created            DateTime  @db.Timestamptz(6)
+  updated            DateTime  @default(now()) @db.Timestamptz(6)
+  livemode           Boolean   @default(false)
+  data               Json      @default("{}")
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
@@ -273,31 +267,33 @@ model ApiKey {
   @@map("api_keys")
 }
 
-/* ===========================
-   Venues, state, requests, music catalog
-   =========================== */
+/**
+ * ===========================
+ * Venues, state, requests, music catalog
+ * ===========================
+ */
 
 model Venue {
-  id                String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  userId            String    @map("userid") @db.Uuid
-  openKjVenueId     Int       @default(autoincrement()) @map("openkj_venue_id")
-  urlName           String    @map("urlname")
-  acceptingRequests Boolean   @default(true) @map("acceptingrequests")
-  hereplaceid       String?   @unique(map: "idx_venues_hereplaceid")
+  id                String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  userId            String   @map("userid") @db.Uuid
+  openKjVenueId     Int      @default(autoincrement()) @map("openkj_venue_id")
+  urlName           String   @map("urlname")
+  acceptingRequests Boolean  @default(true) @map("acceptingrequests")
+  hereplaceid       String?  @unique(map: "idx_venues_hereplaceid")
   name              String
   address           String?
   city              String?
   state             String?
-  stateCode         String?   @map("statecode") @db.VarChar(5)
-  postalCode        String?   @map("postalcode")
+  stateCode         String?  @map("statecode") @db.VarChar(5)
+  postalCode        String?  @map("postalcode")
   country           String?
-  countryCode       String?   @map("countrycode") @db.VarChar(3)
-  phoneNumber       String?   @map("phonenumber") @db.VarChar(20)
+  countryCode       String?  @map("countrycode") @db.VarChar(3)
+  phoneNumber       String?  @map("phonenumber") @db.VarChar(20)
   website           String?
   latitude          Float?
   longitude         Float?
-  createdAt         DateTime  @default(now()) @map("createdat") @db.Timestamptz(6)
-  updatedAt         DateTime  @default(now()) @updatedAt @map("updatedat") @db.Timestamptz(6)
+  createdAt         DateTime @default(now()) @map("createdat") @db.Timestamptz(6)
+  updatedAt         DateTime @default(now()) @updatedAt @map("updatedat") @db.Timestamptz(6)
 
   // relations
   requests Request[]
@@ -305,8 +301,8 @@ model Venue {
   user     User      @relation("UserVenues", fields: [userId], references: [id], onDelete: Cascade)
 
   // back-relations from singer_* tables
-  singerFavoriteVenues  SingerFavoriteVenue[]  @relation("VenueSingerFavoriteVenues")
-  singerRequestHistory  SingerRequestHistory[] @relation("VenueSingerRequestHistory")
+  singerFavoriteVenues SingerFavoriteVenue[]  @relation("VenueSingerFavoriteVenues")
+  singerRequestHistory SingerRequestHistory[] @relation("VenueSingerRequestHistory")
 
   @@unique([userId, name, address], map: "venues_userid_name_address_key")
   @@unique([userId, urlName], map: "venues_userid_urlname_key")
@@ -368,21 +364,23 @@ model Request {
   createdAt DateTime @default(now()) @map("createdat") @db.Timestamptz(6)
   processed Boolean  @default(false)
   singerId  String?  @map("singer_id") @db.Uuid
-  
+
   /// Legacy alias field for backward compatibility.
   /// DB computes this from createdAt (GENERATED ALWAYS ... STORED).
   /// We mark it as dbgenerated so Prisma doesn't try to set it on writes.
-  requestTime DateTime @map("request_time") @default(dbgenerated()) @db.Timestamptz(6)
-  
-  venue  Venue       @relation(fields: [venueId], references: [id], onDelete: Cascade)
+  requestTime DateTime @default(dbgenerated()) @map("request_time") @db.Timestamptz(6)
+
+  venue      Venue       @relation(fields: [venueId], references: [id], onDelete: Cascade)
   singerUser SingerUser? @relation(fields: [singerId], references: [id], onDelete: Cascade)
 
   @@map("requests")
 }
 
-/* ===========================
-   Singer tables
-   =========================== */
+/**
+ * ===========================
+ * Singer tables
+ * ===========================
+ */
 
 model SingerUser {
   id           String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
@@ -396,7 +394,7 @@ model SingerUser {
   favoriteSongs  SingerFavoriteSong[]
   favoriteVenues SingerFavoriteVenue[]
   requestHistory SingerRequestHistory[]
-  requests        Request[]
+  requests       Request[]
 
   @@map("singer_users")
 }
@@ -409,9 +407,9 @@ model SingerFavoriteSong {
   keyChange Int     @default(0) @map("key_change")
 
   singer SingerUser @relation(fields: [singerId], references: [id], onDelete: Cascade)
+  // SQL unique index exists (expression on lower()) but cannot be represented here.
 
   @@map("singer_favorite_songs")
-  // SQL unique index exists (expression on lower()) but cannot be represented here.
 }
 
 model SingerRequestHistory {
@@ -423,19 +421,19 @@ model SingerRequestHistory {
   keyChange   Int      @default(0) @map("key_change")
   requestedAt DateTime @default(now()) @map("requestedat") @db.Timestamptz(6)
 
-  songFingerprint String @map("song_fingerprint") @default(dbgenerated()) @db.Text
+  songFingerprint String @default(dbgenerated()) @map("song_fingerprint") @db.Text
 
   singer SingerUser @relation(fields: [singerId], references: [id], onDelete: Cascade)
   venue  Venue      @relation("VenueSingerRequestHistory", fields: [venueId], references: [id], onDelete: Cascade)
+  // Note: DB indexes exist; not all can be modeled (e.g., BRIN).
 
   @@map("singer_request_history")
-  // Note: DB indexes exist; not all can be modeled (e.g., BRIN).
 }
 
 model SingerFavoriteVenue {
-  singerId String   @map("singer_id") @db.Uuid
-  venueId  String   @map("venue_id")  @db.Uuid
-  createdAt DateTime @default(now())  @map("createdat") @db.Timestamptz(6)
+  singerId  String   @map("singer_id") @db.Uuid
+  venueId   String   @map("venue_id") @db.Uuid
+  createdAt DateTime @default(now()) @map("createdat") @db.Timestamptz(6)
 
   singer SingerUser @relation(fields: [singerId], references: [id], onDelete: Cascade)
   venue  Venue      @relation("VenueSingerFavoriteVenues", fields: [venueId], references: [id], onDelete: Cascade)
@@ -444,9 +442,11 @@ model SingerFavoriteVenue {
   @@map("singer_favorite_venues")
 }
 
-/* ===========================
-   Enums
-   =========================== */
+/**
+ * ===========================
+ * Enums
+ * ===========================
+ */
 
 enum PricingType {
   one_time

--- a/src/app/admin/activity/page.tsx
+++ b/src/app/admin/activity/page.tsx
@@ -1,0 +1,182 @@
+import { requireAdminSession } from '@/lib/admin-auth'
+import { prisma } from '@/lib/prisma'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { formatDistanceToNow } from 'date-fns'
+
+export default async function AdminActivityPage() {
+  await requireAdminSession()
+
+  type ActivityItem = {
+    id: string
+    type: string
+    detail: string
+    account?: string | null
+    meta?: string
+    timestamp: Date
+  }
+
+  const [venues, requests, apiKeys, songs] = await Promise.all([
+    prisma.venue.findMany({
+      orderBy: { createdAt: 'desc' },
+      take: 20,
+      select: {
+        id: true,
+        name: true,
+        createdAt: true,
+        user: {
+          select: {
+            id: true,
+            email: true,
+            name: true,
+          },
+        },
+      },
+    }),
+    prisma.request.findMany({
+      orderBy: { createdAt: 'desc' },
+      take: 40,
+      select: {
+        requestId: true,
+        artist: true,
+        title: true,
+        singer: true,
+        createdAt: true,
+        venue: {
+          select: {
+            id: true,
+            name: true,
+            user: {
+              select: {
+                id: true,
+                email: true,
+                name: true,
+              },
+            },
+          },
+        },
+      },
+    }),
+    prisma.apiKey.findMany({
+      orderBy: { createdAt: 'desc' },
+      take: 20,
+      select: {
+        id: true,
+        description: true,
+        status: true,
+        createdAt: true,
+        customer: {
+          select: {
+            id: true,
+            user: {
+              select: {
+                email: true,
+                name: true,
+              },
+            },
+          },
+        },
+      },
+    }),
+    prisma.songDb.findMany({
+      orderBy: { createdAt: 'desc' },
+      take: 30,
+      select: {
+        songId: true,
+        artist: true,
+        title: true,
+        systemId: true,
+        createdAt: true,
+        user: {
+          select: {
+            id: true,
+            email: true,
+            name: true,
+          },
+        },
+      },
+    }),
+  ])
+
+  const activity: ActivityItem[] = [
+    ...venues.map((venue) => ({
+      id: `venue-${venue.id}`,
+      type: 'Venue created',
+      detail: venue.name,
+      account: venue.user.name || venue.user.email,
+      meta: undefined,
+      timestamp: venue.createdAt,
+    })),
+    ...requests.map((request) => ({
+      id: `request-${request.requestId.toString()}`,
+      type: 'Song request',
+      detail: `${request.artist} – ${request.title}`,
+      account: request.venue?.user?.name || request.venue?.user?.email,
+      meta: request.venue?.name,
+      timestamp: request.createdAt,
+    })),
+    ...apiKeys.map((key) => ({
+      id: `apikey-${key.id}`,
+      type: 'API key',
+      detail: key.description || key.id,
+      account: key.customer.user?.name || key.customer.user?.email,
+      meta: key.status,
+      timestamp: key.createdAt,
+    })),
+    ...songs.map((song) => ({
+      id: `song-${song.songId.toString()}`,
+      type: 'Catalog update',
+      detail: `${song.artist} – ${song.title}`,
+      account: song.user.name || song.user.email,
+      meta: `System ${song.systemId}`,
+      timestamp: song.createdAt,
+    })),
+  ]
+    .sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime())
+    .slice(0, 80)
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold">Global activity</h1>
+        <p className="text-muted-foreground">
+          Unified timeline of customer changes across venues, requests, catalog updates, and integrations.
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Recent events</CardTitle>
+          <CardDescription>Most recent 80 events across all accounts.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {activity.map((item) => (
+            <div
+              key={item.id}
+              className="flex flex-col gap-2 rounded-md border border-slate-200 p-4 sm:flex-row sm:items-center sm:justify-between"
+            >
+              <div className="space-y-1">
+                <div className="flex flex-wrap items-center gap-2">
+                  <Badge variant="outline" className="uppercase tracking-wide text-xs">
+                    {item.type}
+                  </Badge>
+                  <span className="font-medium">{item.detail}</span>
+                </div>
+                <p className="text-sm text-muted-foreground">
+                  Account: {item.account || 'Unknown'}
+                  {item.meta ? ` • ${item.meta}` : ''}
+                </p>
+              </div>
+              <span className="text-sm text-muted-foreground">
+                {formatDistanceToNow(item.timestamp, { addSuffix: true })}
+              </span>
+            </div>
+          ))}
+          {activity.length === 0 && (
+            <p className="text-center text-muted-foreground">No recent activity recorded.</p>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,0 +1,54 @@
+import Link from 'next/link'
+import { requireAdminSession } from '@/lib/admin-auth'
+import { AdminNav } from '@/components/admin-nav'
+import { DashboardHeader } from '@/components/dashboard-header'
+import { Badge } from '@/components/ui/badge'
+
+export default async function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const session = await requireAdminSession()
+
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <header className="bg-white border-b">
+        <div className="container mx-auto px-4 py-4">
+          <div className="flex items-center justify-between">
+            <Link href="/admin" className="flex items-center space-x-2">
+              <img
+                src="/singr-icon.png"
+                alt="Singr Karaoke"
+                className="h-10 w-auto"
+              />
+              <div className="flex flex-col">
+                <span className="text-xl font-bold">Singr Support Portal</span>
+                <span className="text-xs text-muted-foreground">
+                  Empowered admin access for customer assistance
+                </span>
+              </div>
+            </Link>
+
+            <div className="flex items-center gap-4">
+              <Badge variant="secondary" className="uppercase tracking-wide">
+                {(session.user?.adminLevel?.replace(/_/g, ' ') ?? 'support').toUpperCase()}
+              </Badge>
+              <DashboardHeader userEmail={session.user?.email} />
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <div className="flex">
+        <aside className="w-72 bg-white border-r min-h-[calc(100vh-89px)]">
+          <AdminNav />
+        </aside>
+
+        <main className="flex-1 p-8 space-y-8">
+          {children}
+        </main>
+      </div>
+    </div>
+  )
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,215 @@
+import { prisma } from '@/lib/prisma'
+import { requireAdminSession } from '@/lib/admin-auth'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import Link from 'next/link'
+import { Badge } from '@/components/ui/badge'
+
+const numberFormatter = new Intl.NumberFormat('en-US')
+
+export default async function AdminHomePage() {
+  await requireAdminSession()
+
+  const users = await prisma.user.findMany({
+    orderBy: { createdAt: 'desc' },
+    include: {
+      customer: {
+        include: {
+          apiKeys: {
+            select: {
+              id: true,
+            },
+          },
+        },
+      },
+      subscriptions: {
+        select: {
+          status: true,
+          created: true,
+        },
+        orderBy: { created: 'desc' },
+        take: 1,
+      },
+      venues: {
+        select: {
+          id: true,
+          name: true,
+          _count: {
+            select: {
+              requests: true,
+            },
+          },
+        },
+      },
+      _count: {
+        select: {
+          venues: true,
+          songDb: true,
+        },
+      },
+    },
+  })
+
+  const totalCustomers = users.length
+  const activeSubscriptions = users.filter(
+    (user) => user.subscriptions[0]?.status === 'active'
+  ).length
+  const trialingSubscriptions = users.filter(
+    (user) => user.subscriptions[0]?.status === 'trialing'
+  ).length
+  const totalVenues = users.reduce((acc, user) => acc + user._count.venues, 0)
+  const totalSongs = users.reduce((acc, user) => acc + user._count.songDb, 0)
+  const totalRequests = users.reduce(
+    (acc, user) =>
+      acc + user.venues.reduce((venueSum, venue) => venueSum + venue._count.requests, 0),
+    0
+  )
+
+  return (
+    <div className="space-y-8">
+      <div className="flex items-start justify-between">
+        <div>
+          <h1 className="text-3xl font-bold">Customer Directory</h1>
+          <p className="text-muted-foreground">
+            Monitor every account, subscription, and venue across Singr Karaoke.
+          </p>
+        </div>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              Total Customers
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-3xl font-semibold">{numberFormatter.format(totalCustomers)}</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              Active Subscriptions
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-3xl font-semibold">{numberFormatter.format(activeSubscriptions)}</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              Trialing Accounts
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-3xl font-semibold">{numberFormatter.format(trialingSubscriptions)}</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              Total Venues Managed
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-3xl font-semibold">{numberFormatter.format(totalVenues)}</p>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Accounts Overview</CardTitle>
+        </CardHeader>
+        <CardContent className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-slate-200">
+            <thead className="bg-slate-50">
+              <tr>
+                <th className="px-4 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                  Customer
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                  Business
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                  Subscription
+                </th>
+                <th className="px-4 py-3 text-right text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                  Venues
+                </th>
+                <th className="px-4 py-3 text-right text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                  Songs
+                </th>
+                <th className="px-4 py-3 text-right text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                  API Keys
+                </th>
+                <th className="px-4 py-3 text-right text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                  Requests
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                  Created
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-200 bg-white">
+              {users.map((user) => {
+                const subscriptionStatus = user.subscriptions[0]?.status ?? 'none'
+                const requestsCount = user.venues.reduce(
+                  (sum, venue) => sum + venue._count.requests,
+                  0
+                )
+                const apiKeysCount = user.customer?.apiKeys.length ?? 0
+
+                return (
+                  <tr key={user.id} className="hover:bg-slate-50">
+                    <td className="px-4 py-3 whitespace-nowrap">
+                      <Link
+                        href={`/admin/users/${user.id}`}
+                        className="font-medium text-primary hover:underline"
+                      >
+                        {user.name || user.email}
+                      </Link>
+                      <div className="text-xs text-muted-foreground">{user.email}</div>
+                    </td>
+                    <td className="px-4 py-3 whitespace-nowrap text-sm text-slate-700">
+                      {user.businessName || '—'}
+                    </td>
+                    <td className="px-4 py-3 whitespace-nowrap text-sm">
+                      <Badge
+                        variant={
+                          subscriptionStatus === 'active'
+                            ? 'default'
+                            : subscriptionStatus === 'trialing'
+                            ? 'secondary'
+                            : 'outline'
+                        }
+                      >
+                        {subscriptionStatus}
+                      </Badge>
+                    </td>
+                    <td className="px-4 py-3 whitespace-nowrap text-sm text-right">
+                      {numberFormatter.format(user._count.venues)}
+                    </td>
+                    <td className="px-4 py-3 whitespace-nowrap text-sm text-right">
+                      {numberFormatter.format(user._count.songDb)}
+                    </td>
+                    <td className="px-4 py-3 whitespace-nowrap text-sm text-right">
+                      {numberFormatter.format(apiKeysCount)}
+                    </td>
+                    <td className="px-4 py-3 whitespace-nowrap text-sm text-right">
+                      {numberFormatter.format(requestsCount)}
+                    </td>
+                    <td className="px-4 py-3 whitespace-nowrap text-sm text-muted-foreground">
+                      {user.createdAt.toLocaleDateString()}
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/app/admin/users/[userId]/page.tsx
+++ b/src/app/admin/users/[userId]/page.tsx
@@ -1,0 +1,515 @@
+import { notFound } from 'next/navigation'
+import { requireAdminSession } from '@/lib/admin-auth'
+import { prisma } from '@/lib/prisma'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { AdminUserProfileForm } from '@/components/admin/admin-user-profile-form'
+import { AdminCreateVenueForm } from '@/components/admin/admin-create-venue-form'
+import { AdminVenueEditor } from '@/components/admin/admin-venue-editor'
+import { AdminApiKeyGenerator } from '@/components/admin/admin-api-key-generator'
+import { AdminApiKeyRevokeButton } from '@/components/admin/admin-api-key-revoke-button'
+import { Button } from '@/components/ui/button'
+import Link from 'next/link'
+import { formatDistanceToNow } from 'date-fns'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+
+interface AdminUserPageProps {
+  params: { userId: string }
+}
+
+function formatCount(value: number) {
+  return new Intl.NumberFormat('en-US').format(value)
+}
+
+type ActivityItem = {
+  id: string
+  type: string
+  detail: string
+  meta?: string
+  timestamp: Date
+}
+
+export default async function AdminUserPage({ params }: AdminUserPageProps) {
+  const session = await requireAdminSession()
+  const adminLevel = session.user?.adminLevel ?? 'support'
+  const { userId } = params
+
+  const [user, venues, recentRequests, recentSongs] = await Promise.all([
+    prisma.user.findUnique({
+      where: { id: userId },
+      include: {
+        customer: {
+          include: {
+            apiKeys: {
+              orderBy: { createdAt: 'desc' },
+            },
+          },
+        },
+        subscriptions: {
+          orderBy: { created: 'desc' },
+          take: 3,
+        },
+      },
+    }),
+    prisma.venue.findMany({
+      where: { userId },
+      orderBy: { createdAt: 'desc' },
+      select: {
+        id: true,
+        name: true,
+        urlName: true,
+        acceptingRequests: true,
+        address: true,
+        city: true,
+        state: true,
+        stateCode: true,
+        postalCode: true,
+        phoneNumber: true,
+        website: true,
+        createdAt: true,
+        updatedAt: true,
+        _count: {
+          select: {
+            requests: true,
+          },
+        },
+      },
+    }),
+    prisma.request.findMany({
+      where: { venue: { userId } },
+      orderBy: { createdAt: 'desc' },
+      take: 25,
+      select: {
+        requestId: true,
+        artist: true,
+        title: true,
+        singer: true,
+        createdAt: true,
+        venue: {
+          select: {
+            id: true,
+            name: true,
+          },
+        },
+      },
+    }),
+    prisma.songDb.findMany({
+      where: { userId },
+      orderBy: { createdAt: 'desc' },
+      take: 50,
+      select: {
+        songId: true,
+        artist: true,
+        title: true,
+        systemId: true,
+        createdAt: true,
+      },
+    }),
+  ])
+
+  if (!user) {
+    notFound()
+  }
+
+  const apiKeys = user.customer?.apiKeys ?? []
+  const totalVenues = venues.length
+  const totalSongs = await prisma.songDb.count({ where: { userId } })
+  const totalRequests = venues.reduce((acc, venue) => acc + venue._count.requests, 0)
+  const primarySubscription = user.subscriptions[0]
+
+  const activityItems: ActivityItem[] = [
+    ...venues.map((venue) => ({
+      id: `venue-${venue.id}`,
+      type: 'Venue created',
+      detail: venue.name,
+      meta: [venue.city, venue.state].filter(Boolean).join(', ') || undefined,
+      timestamp: venue.createdAt,
+    })),
+    ...recentRequests.map((request) => ({
+      id: `request-${request.requestId.toString()}`,
+      type: 'Song request',
+      detail: `${request.artist} – ${request.title}`,
+      meta: request.venue?.name
+        ? `Venue: ${request.venue.name}${request.singer ? ` • Singer: ${request.singer}` : ''}`
+        : request.singer
+        ? `Singer: ${request.singer}`
+        : undefined,
+      timestamp: request.createdAt,
+    })),
+    ...recentSongs.slice(0, 20).map((song) => ({
+      id: `song-${song.songId.toString()}`,
+      type: 'Catalog update',
+      detail: `${song.artist} – ${song.title}`,
+      meta: `System ${song.systemId}`,
+      timestamp: song.createdAt,
+    })),
+    ...apiKeys.map((key) => ({
+      id: `apiKey-${key.id}`,
+      type: 'API key created',
+      detail: key.description || key.id,
+      meta: `Status: ${key.status}`,
+      timestamp: key.createdAt,
+    })),
+    ...user.subscriptions.map((sub) => ({
+      id: `subscription-${sub.id}`,
+      type: 'Subscription',
+      detail: `${sub.status}`,
+      meta: `Current period ${sub.currentPeriodStart.toLocaleDateString()} – ${sub.currentPeriodEnd.toLocaleDateString()}`,
+      timestamp: sub.created,
+    })),
+  ]
+    .sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime())
+    .slice(0, 40)
+
+  return (
+    <div className="space-y-8">
+      <section className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+        <div className="space-y-2">
+          <div className="flex items-center gap-3">
+            <h1 className="text-3xl font-bold">{user.name || user.email}</h1>
+            <Badge variant="secondary">{primarySubscription?.status ?? 'no subscription'}</Badge>
+          </div>
+          <p className="text-muted-foreground">Customer since {user.createdAt.toLocaleDateString()}</p>
+          <div className="flex flex-wrap gap-3 text-sm text-muted-foreground">
+            <span>Email: {user.email}</span>
+            {user.businessName && <span>Business: {user.businessName}</span>}
+            {user.phoneNumber && <span>Phone: {user.phoneNumber}</span>}
+          </div>
+        </div>
+        <Card className="min-w-[260px]">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              Account Snapshot
+            </CardTitle>
+            <CardDescription>Key metrics for this customer</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-2 text-sm">
+            <div className="flex items-center justify-between">
+              <span className="text-muted-foreground">Venues</span>
+              <span className="font-semibold">{formatCount(totalVenues)}</span>
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="text-muted-foreground">Songs in catalog</span>
+              <span className="font-semibold">{formatCount(totalSongs)}</span>
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="text-muted-foreground">Total requests</span>
+              <span className="font-semibold">{formatCount(totalRequests)}</span>
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="text-muted-foreground">API keys</span>
+              <span className="font-semibold">{formatCount(apiKeys.length)}</span>
+            </div>
+          </CardContent>
+        </Card>
+      </section>
+
+      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <Link href="#profile" className="group">
+          <Card className="border-dashed group-hover:border-primary transition-colors">
+            <CardHeader>
+              <CardTitle>Profile</CardTitle>
+              <CardDescription>Identity, business, and contact information</CardDescription>
+            </CardHeader>
+          </Card>
+        </Link>
+        <Link href="#venues" className="group">
+          <Card className="border-dashed group-hover:border-primary transition-colors">
+            <CardHeader>
+              <CardTitle>Venues</CardTitle>
+              <CardDescription>Manage {totalVenues} active location(s)</CardDescription>
+            </CardHeader>
+          </Card>
+        </Link>
+        <Link href="#api-keys" className="group">
+          <Card className="border-dashed group-hover:border-primary transition-colors">
+            <CardHeader>
+              <CardTitle>API Keys</CardTitle>
+              <CardDescription>Create and review integration credentials</CardDescription>
+            </CardHeader>
+          </Card>
+        </Link>
+        <Link href="#activity" className="group">
+          <Card className="border-dashed group-hover:border-primary transition-colors">
+            <CardHeader>
+              <CardTitle>Activity</CardTitle>
+              <CardDescription>Latest requests, venues, and catalog updates</CardDescription>
+            </CardHeader>
+          </Card>
+        </Link>
+      </section>
+
+      <section id="profile" className="grid gap-6 lg:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle>Customer profile</CardTitle>
+            <CardDescription>Update customer-facing details and contact information.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <AdminUserProfileForm
+              userId={userId}
+              name={user.name}
+              businessName={user.businessName}
+              phoneNumber={user.phoneNumber}
+              adminLevel={adminLevel}
+            />
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>Account assistance</CardTitle>
+            <CardDescription>Tools to support the customer quickly.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <Alert>
+              <AlertDescription>
+                Password reset links and session impersonation are not yet available in the shared database. We recommend logging a
+                follow-up task to introduce secure reset tokens.
+              </AlertDescription>
+            </Alert>
+            <Button variant="outline" disabled>
+              Generate password reset link (coming soon)
+            </Button>
+          </CardContent>
+        </Card>
+      </section>
+
+      <section id="venues" className="space-y-6">
+        <div className="flex flex-col gap-2">
+          <h2 className="text-2xl font-semibold">Venues</h2>
+          <p className="text-muted-foreground">
+            Create venues on behalf of the customer and make adjustments to existing locations.
+          </p>
+        </div>
+        <Card>
+          <CardHeader>
+            <CardTitle>Create a new venue</CardTitle>
+            <CardDescription>Provision a new location that is linked to this customer account.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <AdminCreateVenueForm userId={userId} adminLevel={adminLevel} />
+          </CardContent>
+        </Card>
+
+        <div className="grid gap-6">
+          {venues.map((venue) => (
+            <Card key={venue.id}>
+              <CardHeader className="flex flex-col gap-1">
+                <div className="flex items-center justify-between">
+                  <CardTitle>{venue.name}</CardTitle>
+                  <Badge variant={venue.acceptingRequests ? 'default' : 'outline'}>
+                    {venue.acceptingRequests ? 'Accepting requests' : 'Paused'}
+                  </Badge>
+                </div>
+                <CardDescription>
+                  Opened {formatDistanceToNow(venue.createdAt, { addSuffix: true })} • {venue._count.requests} total requests
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <AdminVenueEditor venue={venue} adminLevel={adminLevel} />
+              </CardContent>
+            </Card>
+          ))}
+          {venues.length === 0 && (
+            <Card>
+              <CardContent className="py-12 text-center text-muted-foreground">
+                No venues created yet. Use the form above to add their first location.
+              </CardContent>
+            </Card>
+          )}
+        </div>
+      </section>
+
+      <section id="api-keys" className="space-y-6">
+        <div className="flex flex-col gap-2">
+          <h2 className="text-2xl font-semibold">API keys</h2>
+          <p className="text-muted-foreground">
+            Generate new keys and review the history of integrations tied to this customer.
+          </p>
+        </div>
+        <Card>
+          <CardHeader>
+            <CardTitle>Generate a new API key</CardTitle>
+            <CardDescription>Create keys on behalf of the customer and share securely.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <AdminApiKeyGenerator userId={userId} adminLevel={adminLevel} />
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Existing keys</CardTitle>
+            <CardDescription>Active and historical keys linked to this account.</CardDescription>
+          </CardHeader>
+          <CardContent className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-slate-200">
+              <thead className="bg-slate-50 text-left text-xs font-medium uppercase text-muted-foreground">
+                <tr>
+                  <th className="px-4 py-2">Description</th>
+                  <th className="px-4 py-2">Status</th>
+                  <th className="px-4 py-2">Created</th>
+                  <th className="px-4 py-2">Last used</th>
+                  <th className="px-4 py-2">Actions</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-200 text-sm">
+                {apiKeys.map((key) => (
+                  <tr key={key.id}>
+                    <td className="px-4 py-2 font-medium">{key.description || '—'}</td>
+                    <td className="px-4 py-2">
+                      <Badge variant={key.status === 'active' ? 'default' : 'outline'}>{key.status}</Badge>
+                    </td>
+                    <td className="px-4 py-2 text-muted-foreground">
+                      {key.createdAt.toLocaleString()}
+                    </td>
+                    <td className="px-4 py-2 text-muted-foreground">
+                      {key.lastUsedAt ? key.lastUsedAt.toLocaleString() : 'Never'}
+                    </td>
+                    <td className="px-4 py-2">
+                      <AdminApiKeyRevokeButton
+                        apiKeyId={key.id}
+                        status={key.status}
+                        adminLevel={adminLevel}
+                      />
+                    </td>
+                  </tr>
+                ))}
+                {apiKeys.length === 0 && (
+                  <tr>
+                    <td colSpan={5} className="px-4 py-6 text-center text-muted-foreground">
+                      No API keys have been generated yet.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </CardContent>
+        </Card>
+      </section>
+
+      <section id="requests" className="space-y-6">
+        <div className="flex flex-col gap-2">
+          <h2 className="text-2xl font-semibold">Recent requests</h2>
+          <p className="text-muted-foreground">
+            The latest 25 requests submitted across all venues for this account.
+          </p>
+        </div>
+        <Card>
+          <CardContent className="overflow-x-auto p-0">
+            <table className="min-w-full divide-y divide-slate-200 text-sm">
+              <thead className="bg-slate-50 text-left text-xs font-medium uppercase text-muted-foreground">
+                <tr>
+                  <th className="px-4 py-2">Song</th>
+                  <th className="px-4 py-2">Venue</th>
+                  <th className="px-4 py-2">Singer</th>
+                  <th className="px-4 py-2">Requested</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-200">
+                {recentRequests.map((request) => (
+                  <tr key={request.requestId.toString()}>
+                    <td className="px-4 py-2 font-medium">
+                      {request.artist} – {request.title}
+                    </td>
+                    <td className="px-4 py-2 text-muted-foreground">
+                      {request.venue?.name || '—'}
+                    </td>
+                    <td className="px-4 py-2 text-muted-foreground">{request.singer || '—'}</td>
+                    <td className="px-4 py-2 text-muted-foreground">
+                      {formatDistanceToNow(request.createdAt, { addSuffix: true })}
+                    </td>
+                  </tr>
+                ))}
+                {recentRequests.length === 0 && (
+                  <tr>
+                    <td colSpan={4} className="px-4 py-6 text-center text-muted-foreground">
+                      No requests recorded for this account yet.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </CardContent>
+        </Card>
+      </section>
+
+      <section id="songs" className="space-y-6">
+        <div className="flex flex-col gap-2">
+          <h2 className="text-2xl font-semibold">Song catalog</h2>
+          <p className="text-muted-foreground">
+            A rolling log of the 50 most recent songs added to the customer library.
+          </p>
+        </div>
+        <Card>
+          <CardContent className="overflow-x-auto p-0">
+            <table className="min-w-full divide-y divide-slate-200 text-sm">
+              <thead className="bg-slate-50 text-left text-xs font-medium uppercase text-muted-foreground">
+                <tr>
+                  <th className="px-4 py-2">Song</th>
+                  <th className="px-4 py-2">System</th>
+                  <th className="px-4 py-2">Added</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-200">
+                {recentSongs.map((song) => (
+                  <tr key={song.songId.toString()}>
+                    <td className="px-4 py-2 font-medium">
+                      {song.artist} – {song.title}
+                    </td>
+                    <td className="px-4 py-2 text-muted-foreground">{song.systemId}</td>
+                    <td className="px-4 py-2 text-muted-foreground">
+                      {formatDistanceToNow(song.createdAt, { addSuffix: true })}
+                    </td>
+                  </tr>
+                ))}
+                {recentSongs.length === 0 && (
+                  <tr>
+                    <td colSpan={3} className="px-4 py-6 text-center text-muted-foreground">
+                      No songs have been imported into this account yet.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </CardContent>
+        </Card>
+      </section>
+
+      <section id="activity" className="space-y-6">
+        <div className="flex flex-col gap-2">
+          <h2 className="text-2xl font-semibold">Activity timeline</h2>
+          <p className="text-muted-foreground">
+            Combined operational log of venue creation, catalog updates, API key issuance, and requests.
+          </p>
+        </div>
+        <Card>
+          <CardContent className="space-y-4">
+            {activityItems.map((item) => (
+              <div
+                key={item.id}
+                className="flex flex-col gap-1 rounded-md border border-slate-200 p-4 sm:flex-row sm:items-center sm:justify-between"
+              >
+                <div className="space-y-1">
+                  <div className="flex items-center gap-2">
+                    <Badge variant="outline" className="uppercase tracking-wide text-xs">
+                      {item.type}
+                    </Badge>
+                    <span className="font-medium">{item.detail}</span>
+                  </div>
+                  {item.meta && <p className="text-sm text-muted-foreground">{item.meta}</p>}
+                </div>
+                <span className="text-sm text-muted-foreground">
+                  {formatDistanceToNow(item.timestamp, { addSuffix: true })}
+                </span>
+              </div>
+            ))}
+            {activityItems.length === 0 && (
+              <p className="text-center text-muted-foreground">No tracked activity for this account yet.</p>
+            )}
+          </CardContent>
+        </Card>
+      </section>
+    </div>
+  )
+}

--- a/src/app/api/admin/api-keys/[id]/revoke/route.ts
+++ b/src/app/api/admin/api-keys/[id]/revoke/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getAdminSession, assertAdminLevel } from '@/lib/admin-auth'
+import { prisma } from '@/lib/prisma'
+import { logger } from '@/lib/logger'
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const session = await getAdminSession()
+
+  if (!assertAdminLevel(session, 'super_admin')) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const { id } = params
+
+  try {
+    const apiKey = await prisma.apiKey.findUnique({
+      where: { id },
+      select: {
+        id: true,
+        status: true,
+        revokedAt: true,
+        customer: {
+          select: {
+            id: true,
+          },
+        },
+      },
+    })
+
+    if (!apiKey) {
+      return NextResponse.json({ error: 'API key not found' }, { status: 404 })
+    }
+
+    if (apiKey.revokedAt) {
+      return NextResponse.json({ success: true })
+    }
+
+    await prisma.apiKey.update({
+      where: { id },
+      data: {
+        status: 'revoked',
+        revokedAt: new Date(),
+      },
+    })
+
+    logger.info('Admin revoked API key', {
+      adminId: session?.user?.adminId,
+      apiKeyId: id,
+      targetCustomerId: apiKey.customer.id,
+    })
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    logger.error('Failed to revoke API key as admin', { error })
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/admin/users/[userId]/api-keys/route.ts
+++ b/src/app/api/admin/users/[userId]/api-keys/route.ts
@@ -1,0 +1,81 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getAdminSession, assertAdminLevel } from '@/lib/admin-auth'
+import { prisma } from '@/lib/prisma'
+import { generateApiKey } from '@/lib/utils'
+import bcrypt from 'bcryptjs'
+import { logger } from '@/lib/logger'
+import { z } from 'zod'
+
+const createApiKeySchema = z.object({
+  description: z.string().min(1, 'Description is required'),
+})
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { userId: string } }
+) {
+  const session = await getAdminSession()
+
+  if (!assertAdminLevel(session)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { userId } = params
+
+  try {
+    const body = await request.json()
+    const { description } = createApiKeySchema.parse(body)
+
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { id: true, email: true },
+    })
+
+    if (!user) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 })
+    }
+
+    const apiKey = generateApiKey()
+    const apiKeyHash = await bcrypt.hash(apiKey, 12)
+
+    const customer = await prisma.customer.upsert({
+      where: { id: userId },
+      update: {},
+      create: {
+        id: userId,
+        stripeCustomerId: `temp_${userId}`,
+      },
+    })
+
+    const apiKeyRecord = await prisma.apiKey.create({
+      data: {
+        customerId: customer.id,
+        description,
+        apiKeyHash,
+        status: 'active',
+      },
+    })
+
+    logger.info('Admin generated API key', {
+      adminId: session?.user?.adminId,
+      adminLevel: session?.user?.adminLevel,
+      targetUserId: userId,
+      apiKeyId: apiKeyRecord.id,
+    })
+
+    return NextResponse.json({
+      id: apiKeyRecord.id,
+      apiKey,
+      description: apiKeyRecord.description,
+      status: apiKeyRecord.status,
+      createdAt: apiKeyRecord.createdAt,
+    })
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ error: error.errors[0].message }, { status: 400 })
+    }
+
+    logger.error('Failed to create API key as admin', { error })
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/admin/users/[userId]/profile/route.ts
+++ b/src/app/api/admin/users/[userId]/profile/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getAdminSession, assertAdminLevel } from '@/lib/admin-auth'
+import { prisma } from '@/lib/prisma'
+import { z } from 'zod'
+import { logger } from '@/lib/logger'
+
+const updateUserSchema = z.object({
+  name: z.string().optional().nullable(),
+  businessName: z.string().optional().nullable(),
+  phoneNumber: z.string().optional().nullable(),
+})
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { userId: string } }
+) {
+  const session = await getAdminSession()
+
+  if (!assertAdminLevel(session, 'super_admin')) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const { userId } = params
+
+  try {
+    const body = await request.json()
+    const validatedData = updateUserSchema.parse(body)
+
+    const user = await prisma.user.findUnique({ where: { id: userId } })
+
+    if (!user) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 })
+    }
+
+    const updateData: Record<string, unknown> = { updatedAt: new Date() }
+
+    if (validatedData.name !== undefined) {
+      updateData.name = validatedData.name || null
+    }
+    if (validatedData.businessName !== undefined) {
+      updateData.businessName = validatedData.businessName || null
+    }
+    if (validatedData.phoneNumber !== undefined) {
+      updateData.phoneNumber = validatedData.phoneNumber || null
+    }
+
+    if (Object.keys(updateData).length === 1) {
+      return NextResponse.json({ error: 'No changes supplied' }, { status: 400 })
+    }
+
+    const updatedUser = await prisma.user.update({
+      where: { id: userId },
+      data: updateData,
+    })
+
+    logger.info('Admin updated customer profile', {
+      adminId: session?.user?.adminId,
+      targetUserId: userId,
+    })
+
+    return NextResponse.json({
+      id: updatedUser.id,
+      name: updatedUser.name,
+      businessName: updatedUser.businessName,
+      phoneNumber: updatedUser.phoneNumber,
+      email: updatedUser.email,
+    })
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ error: error.errors[0].message }, { status: 400 })
+    }
+
+    logger.error('Failed to update user profile as admin', { error })
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/admin/users/[userId]/venues/route.ts
+++ b/src/app/api/admin/users/[userId]/venues/route.ts
@@ -1,0 +1,163 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getAdminSession, assertAdminLevel } from '@/lib/admin-auth'
+import { prisma } from '@/lib/prisma'
+import { z } from 'zod'
+import { logger } from '@/lib/logger'
+
+const createVenueSchema = z.object({
+  name: z.string().min(1, 'Venue name is required'),
+  urlName: z
+    .string()
+    .min(1, 'URL name is required')
+    .regex(/^[a-z0-9-]+$/, 'URL name can only contain lowercase letters, numbers, and hyphens'),
+  address: z.string().optional(),
+  city: z.string().optional(),
+  state: z.string().optional(),
+  stateCode: z.string().optional(),
+  postalCode: z.string().optional(),
+  country: z.string().default('US'),
+  countryCode: z.string().optional(),
+  phoneNumber: z.string().optional(),
+  website: z.string().optional(),
+  acceptingRequests: z.boolean().default(true),
+})
+
+async function geocodeAddress(address: string) {
+  const apiKey = process.env.HERE_API_KEY
+  if (!apiKey) return null
+
+  try {
+    const url = `https://geocode.search.hereapi.com/v1/geocode?q=${encodeURIComponent(address)}&apiKey=${apiKey}`
+    const response = await fetch(url)
+
+    if (!response.ok) return null
+
+    const data = await response.json()
+    const firstResult = data.items?.[0]
+
+    if (firstResult?.position) {
+      return {
+        lat: firstResult.position.lat as number,
+        lng: firstResult.position.lng as number,
+      }
+    }
+  } catch (error) {
+    logger.warn('Failed to geocode address for admin venue creation', { error })
+  }
+
+  return null
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { userId: string } }
+) {
+  const session = await getAdminSession()
+
+  if (!assertAdminLevel(session)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { userId } = params
+
+  try {
+    const body = await request.json()
+    const validatedData = createVenueSchema.parse(body)
+
+    const targetUser = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { id: true, email: true },
+    })
+
+    if (!targetUser) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 })
+    }
+
+    const existingVenue = await prisma.venue.findFirst({
+      where: {
+        userId,
+        urlName: validatedData.urlName,
+      },
+    })
+
+    if (existingVenue) {
+      return NextResponse.json(
+        { error: 'URL name is already in use for this customer' },
+        { status: 400 }
+      )
+    }
+
+    let coordinates: { lat: number; lng: number } | null = null
+    if (validatedData.address && (!validatedData.countryCode || !validatedData.stateCode)) {
+      const addressParts = [
+        validatedData.address,
+        validatedData.city,
+        validatedData.state,
+        validatedData.postalCode,
+      ]
+        .filter(Boolean)
+        .join(' ')
+
+      if (addressParts) {
+        coordinates = await geocodeAddress(addressParts)
+      }
+    }
+
+    const venue = await prisma.venue.create({
+      data: {
+        userId,
+        name: validatedData.name,
+        urlName: validatedData.urlName,
+        acceptingRequests: validatedData.acceptingRequests,
+        address: validatedData.address,
+        city: validatedData.city,
+        state: validatedData.state,
+        stateCode: validatedData.stateCode || null,
+        postalCode: validatedData.postalCode,
+        country: validatedData.country,
+        countryCode: validatedData.countryCode || null,
+        phoneNumber: validatedData.phoneNumber,
+        website: validatedData.website,
+        latitude: coordinates?.lat,
+        longitude: coordinates?.lng,
+      },
+    })
+
+    await prisma.state.create({
+      data: {
+        venueId: venue.id,
+        systemId: 0,
+        accepting: validatedData.acceptingRequests,
+        serial: 1,
+      },
+    })
+
+    logger.info('Admin created venue on behalf of user', {
+      adminId: session?.user?.adminId,
+      adminLevel: session?.user?.adminLevel,
+      targetUserId: userId,
+      venueId: venue.id,
+    })
+
+    return NextResponse.json({
+      id: venue.id,
+      name: venue.name,
+      urlName: venue.urlName,
+      acceptingRequests: venue.acceptingRequests,
+      address: venue.address,
+      city: venue.city,
+      state: venue.state,
+      postalCode: venue.postalCode,
+      country: venue.country,
+      phoneNumber: venue.phoneNumber,
+      website: venue.website,
+    })
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ error: error.errors[0].message }, { status: 400 })
+    }
+
+    logger.error('Failed to create venue as admin', { error })
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/admin/venues/[venueId]/route.ts
+++ b/src/app/api/admin/venues/[venueId]/route.ts
@@ -1,0 +1,149 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getAdminSession, assertAdminLevel } from '@/lib/admin-auth'
+import { prisma } from '@/lib/prisma'
+import { z } from 'zod'
+import { logger } from '@/lib/logger'
+
+const updateVenueSchema = z.object({
+  name: z.string().optional(),
+  acceptingRequests: z.boolean().optional(),
+  address: z.string().optional().nullable(),
+  city: z.string().optional().nullable(),
+  state: z.string().optional().nullable(),
+  stateCode: z.string().optional().nullable(),
+  postalCode: z.string().optional().nullable(),
+  phoneNumber: z.string().optional().nullable(),
+  website: z.string().optional().nullable(),
+})
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { venueId: string } }
+) {
+  const session = await getAdminSession()
+
+  if (!assertAdminLevel(session, 'super_admin')) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const { venueId } = params
+
+  try {
+    const existingVenue = await prisma.venue.findUnique({
+      where: { id: venueId },
+      select: { id: true, userId: true },
+    })
+
+    if (!existingVenue) {
+      return NextResponse.json({ error: 'Venue not found' }, { status: 404 })
+    }
+
+    const body = await request.json()
+    const validatedData = updateVenueSchema.parse(body)
+
+    const data: Record<string, any> = {}
+
+    if (validatedData.name !== undefined) {
+      data.name = validatedData.name
+    }
+    if (validatedData.acceptingRequests !== undefined) {
+      data.acceptingRequests = validatedData.acceptingRequests
+    }
+    if (validatedData.address !== undefined) {
+      data.address = validatedData.address || null
+    }
+    if (validatedData.city !== undefined) {
+      data.city = validatedData.city || null
+    }
+    if (validatedData.state !== undefined) {
+      data.state = validatedData.state || null
+    }
+    if (validatedData.stateCode !== undefined) {
+      data.stateCode = validatedData.stateCode || null
+    }
+    if (validatedData.postalCode !== undefined) {
+      data.postalCode = validatedData.postalCode || null
+    }
+    if (validatedData.phoneNumber !== undefined) {
+      data.phoneNumber = validatedData.phoneNumber || null
+    }
+    if (validatedData.website !== undefined) {
+      data.website = validatedData.website || null
+    }
+
+    if (Object.keys(data).length === 0) {
+      return NextResponse.json({ error: 'No changes supplied' }, { status: 400 })
+    }
+
+    const updatedVenue = await prisma.venue.update({
+      where: { id: venueId },
+      data: {
+        ...data,
+        updatedAt: new Date(),
+      },
+    })
+
+    logger.info('Admin updated venue', {
+      adminId: session?.user?.adminId,
+      adminLevel: session?.user?.adminLevel,
+      venueId,
+      targetUserId: existingVenue.userId,
+    })
+
+    return NextResponse.json({
+      id: updatedVenue.id,
+      name: updatedVenue.name,
+      acceptingRequests: updatedVenue.acceptingRequests,
+      address: updatedVenue.address,
+      city: updatedVenue.city,
+      state: updatedVenue.state,
+      postalCode: updatedVenue.postalCode,
+      phoneNumber: updatedVenue.phoneNumber,
+      website: updatedVenue.website,
+    })
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ error: error.errors[0].message }, { status: 400 })
+    }
+
+    logger.error('Failed to update venue as admin', { error })
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: { venueId: string } }
+) {
+  const session = await getAdminSession()
+
+  if (!assertAdminLevel(session, 'super_admin')) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const { venueId } = params
+
+  try {
+    const venue = await prisma.venue.findUnique({
+      where: { id: venueId },
+      select: { id: true, userId: true },
+    })
+
+    if (!venue) {
+      return NextResponse.json({ error: 'Venue not found' }, { status: 404 })
+    }
+
+    await prisma.venue.delete({ where: { id: venueId } })
+
+    logger.info('Admin deleted venue', {
+      adminId: session?.user?.adminId,
+      venueId,
+      targetUserId: venue.userId,
+    })
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    logger.error('Failed to delete venue as admin', { error })
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -22,8 +22,9 @@ export default function SignInPage() {
   // Redirect if already logged in
   useEffect(() => {
     if (status === 'loading') return // Still loading
-    if (session) {
-      router.push('/dashboard')
+    if (session?.user) {
+      const destination = session.user.accountType === 'admin' ? '/admin' : '/dashboard'
+      router.push(destination)
     }
   }, [session, status, router])
 
@@ -44,8 +45,9 @@ export default function SignInPage() {
       } else {
         // Check if sign in was successful
         const session = await getSession()
-        if (session) {
-          router.push('/dashboard')
+        if (session?.user) {
+          const destination = session.user.accountType === 'admin' ? '/admin' : '/dashboard'
+          router.push(destination)
         }
       }
     } catch (error) {

--- a/src/components/admin-nav.tsx
+++ b/src/components/admin-nav.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { cn } from '@/lib/utils'
+
+const navigation = [
+  { name: 'Customer Directory', href: '/admin' },
+  { name: 'Global Activity', href: '/admin/activity' },
+]
+
+export function AdminNav() {
+  const pathname = usePathname()
+
+  return (
+    <nav className="p-4 space-y-2">
+      {navigation.map((item) => {
+        const isActive = pathname === item.href || pathname?.startsWith(`${item.href}/`)
+        return (
+          <Link
+            key={item.name}
+            href={item.href}
+            className={cn(
+              'block px-3 py-2 rounded-md text-sm font-medium transition-colors',
+              isActive
+                ? 'bg-primary text-primary-foreground'
+                : 'text-muted-foreground hover:text-foreground hover:bg-muted'
+            )}
+          >
+            {item.name}
+          </Link>
+        )
+      })}
+    </nav>
+  )
+}

--- a/src/components/admin/admin-api-key-generator.tsx
+++ b/src/components/admin/admin-api-key-generator.tsx
@@ -1,0 +1,121 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+
+interface AdminApiKeyGeneratorProps {
+  userId: string
+  adminLevel: 'support' | 'super_admin'
+}
+
+export function AdminApiKeyGenerator({ userId, adminLevel }: AdminApiKeyGeneratorProps) {
+  const router = useRouter()
+  const isSupport = adminLevel === 'support'
+  const [description, setDescription] = useState('')
+  const [isGenerating, setIsGenerating] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [generatedKey, setGeneratedKey] = useState<string | null>(null)
+
+  const handleGenerate = async (event: React.FormEvent) => {
+    event.preventDefault()
+    setError(null)
+    setGeneratedKey(null)
+
+    if (!description.trim()) {
+      setError('Please provide a description for the new API key.')
+      return
+    }
+
+    setIsGenerating(true)
+
+    try {
+      const response = await fetch(`/api/admin/users/${userId}/api-keys`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ description }),
+      })
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}))
+        throw new Error(data.error || 'Failed to generate API key')
+      }
+
+      const data = await response.json()
+      setGeneratedKey(data.apiKey)
+      setDescription('')
+      router.refresh()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to generate API key')
+    } finally {
+      setIsGenerating(false)
+    }
+  }
+
+  const handleCopy = async () => {
+    if (!generatedKey) return
+
+    try {
+      await navigator.clipboard.writeText(generatedKey)
+      setError(null)
+    } catch (err) {
+      setError('Unable to copy API key to clipboard')
+    }
+  }
+
+  return (
+    <form onSubmit={handleGenerate} className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="admin-api-key-description">API Key Description</Label>
+        <Input
+          id="admin-api-key-description"
+          value={description}
+          onChange={(event) => setDescription(event.target.value)}
+          placeholder="Production integration, Zapier, etc."
+          disabled={isGenerating}
+        />
+      </div>
+
+      <Button type="submit" disabled={isGenerating}>
+        {isGenerating ? 'Generating...' : 'Generate new API key'}
+      </Button>
+
+      {isSupport && (
+        <Alert>
+          <AlertDescription>
+            Support admins can provision API keys but cannot revoke existing keys. Contact a super admin for lifecycle changes.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {error && (
+        <Alert variant="destructive">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      {generatedKey && (
+        <Alert>
+          <AlertDescription className="space-y-2">
+            <div>
+              API key generated successfully. This value will not be shown again—copy it now and share securely with the customer.
+            </div>
+            <div className="flex flex-col gap-2">
+              <code className="rounded-md bg-muted px-3 py-2 text-sm break-words">{generatedKey}</code>
+              <div className="flex gap-2">
+                <Button type="button" variant="outline" onClick={handleCopy}>
+                  Copy to clipboard
+                </Button>
+              </div>
+            </div>
+          </AlertDescription>
+        </Alert>
+      )}
+    </form>
+  )
+}

--- a/src/components/admin/admin-api-key-revoke-button.tsx
+++ b/src/components/admin/admin-api-key-revoke-button.tsx
@@ -1,0 +1,69 @@
+'use client'
+
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { useRouter } from 'next/navigation'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+
+interface AdminApiKeyRevokeButtonProps {
+  apiKeyId: string
+  status: string
+  adminLevel: 'support' | 'super_admin'
+}
+
+export function AdminApiKeyRevokeButton({
+  apiKeyId,
+  status,
+  adminLevel,
+}: AdminApiKeyRevokeButtonProps) {
+  const router = useRouter()
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const isRevoked = status !== 'active'
+  const isSuperAdmin = adminLevel === 'super_admin'
+
+  if (!isSuperAdmin) {
+    return null
+  }
+
+  const handleRevoke = async () => {
+    setIsLoading(true)
+    setError(null)
+
+    try {
+      const response = await fetch(`/api/admin/api-keys/${apiKeyId}/revoke`, {
+        method: 'POST',
+      })
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}))
+        throw new Error(data.error || 'Failed to revoke API key')
+      }
+
+      router.refresh()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to revoke API key')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      {error && (
+        <Alert variant="destructive">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={handleRevoke}
+        disabled={isLoading || isRevoked}
+      >
+        {isRevoked ? 'Revoked' : isLoading ? 'Revoking…' : 'Revoke key'}
+      </Button>
+    </div>
+  )
+}

--- a/src/components/admin/admin-create-venue-form.tsx
+++ b/src/components/admin/admin-create-venue-form.tsx
@@ -1,0 +1,242 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Switch } from '@/components/ui/switch'
+
+interface AdminCreateVenueFormProps {
+  userId: string
+  adminLevel: 'support' | 'super_admin'
+}
+
+const toSlug = (value: string) =>
+  value
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)+/g, '')
+
+export function AdminCreateVenueForm({ userId, adminLevel }: AdminCreateVenueFormProps) {
+  const router = useRouter()
+  const isSupport = adminLevel === 'support'
+  const [formState, setFormState] = useState({
+    name: '',
+    urlName: '',
+    address: '',
+    city: '',
+    state: '',
+    postalCode: '',
+    country: 'United States',
+    countryCode: 'US',
+    phoneNumber: '',
+    website: '',
+    acceptingRequests: true,
+  })
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+
+  const handleChange = (field: string, value: string | boolean) => {
+    setFormState((prev) => ({ ...prev, [field]: value }))
+    setError(null)
+    setSuccess(null)
+  }
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault()
+    setError(null)
+    setSuccess(null)
+
+    if (!formState.name.trim() || !formState.urlName.trim()) {
+      setError('Name and URL name are required')
+      return
+    }
+
+    setIsSubmitting(true)
+
+    try {
+      const response = await fetch(`/api/admin/users/${userId}/venues`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          name: formState.name,
+          urlName: formState.urlName,
+          address: formState.address || undefined,
+          city: formState.city || undefined,
+          state: formState.state || undefined,
+          postalCode: formState.postalCode || undefined,
+          country: formState.countryCode || 'US',
+          countryCode: formState.countryCode || 'US',
+          phoneNumber: formState.phoneNumber || undefined,
+          website: formState.website || undefined,
+          acceptingRequests: formState.acceptingRequests,
+        }),
+      })
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}))
+        throw new Error(data.error || 'Failed to create venue')
+      }
+
+      const data = await response.json()
+      setSuccess(`Venue ${data.name} created successfully`)
+      setFormState((prev) => ({
+        ...prev,
+        name: '',
+        urlName: '',
+        address: '',
+        city: '',
+        state: '',
+        postalCode: '',
+        phoneNumber: '',
+        website: '',
+        acceptingRequests: true,
+      }))
+      router.refresh()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create venue')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      {isSupport && (
+        <Alert>
+          <AlertDescription>
+            Support admins can create venues for customers. Any changes to existing venues must be escalated to a super admin.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {error && (
+        <Alert variant="destructive">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+      {success && (
+        <Alert>
+          <AlertDescription>{success}</AlertDescription>
+        </Alert>
+      )}
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="space-y-2">
+          <Label htmlFor="admin-new-venue-name">Venue Name</Label>
+          <Input
+            id="admin-new-venue-name"
+            value={formState.name}
+            onChange={(event) => {
+              const name = event.target.value
+              handleChange('name', name)
+              if (!formState.urlName || formState.urlName === toSlug(formState.name)) {
+                handleChange('urlName', toSlug(name))
+              }
+            }}
+            placeholder="Singr Lounge Downtown"
+            disabled={isSubmitting}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="admin-new-venue-url">URL Name</Label>
+          <Input
+            id="admin-new-venue-url"
+            value={formState.urlName}
+            onChange={(event) => handleChange('urlName', toSlug(event.target.value))}
+            placeholder="singr-lounge-downtown"
+            disabled={isSubmitting}
+          />
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="admin-new-venue-address">Address</Label>
+        <Input
+          id="admin-new-venue-address"
+          value={formState.address}
+          onChange={(event) => handleChange('address', event.target.value)}
+          placeholder="123 Main Street"
+          disabled={isSubmitting}
+        />
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-3">
+        <div className="space-y-2">
+          <Label htmlFor="admin-new-venue-city">City</Label>
+          <Input
+            id="admin-new-venue-city"
+            value={formState.city}
+            onChange={(event) => handleChange('city', event.target.value)}
+            disabled={isSubmitting}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="admin-new-venue-state">State</Label>
+          <Input
+            id="admin-new-venue-state"
+            value={formState.state}
+            onChange={(event) => handleChange('state', event.target.value)}
+            disabled={isSubmitting}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="admin-new-venue-postal">Postal Code</Label>
+          <Input
+            id="admin-new-venue-postal"
+            value={formState.postalCode}
+            onChange={(event) => handleChange('postalCode', event.target.value)}
+            disabled={isSubmitting}
+          />
+        </div>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="space-y-2">
+          <Label htmlFor="admin-new-venue-phone">Phone</Label>
+          <Input
+            id="admin-new-venue-phone"
+            value={formState.phoneNumber}
+            onChange={(event) => handleChange('phoneNumber', event.target.value)}
+            placeholder="+1 (555) 123-4567"
+            disabled={isSubmitting}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="admin-new-venue-website">Website</Label>
+          <Input
+            id="admin-new-venue-website"
+            value={formState.website}
+            onChange={(event) => handleChange('website', event.target.value)}
+            placeholder="https://example.com"
+            disabled={isSubmitting}
+          />
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between rounded-md border p-3">
+        <div>
+          <Label className="text-sm font-medium">Accepting Requests</Label>
+          <p className="text-xs text-muted-foreground">
+            New venues default to accepting requests. Toggle off for closed locations.
+          </p>
+        </div>
+        <Switch
+          checked={formState.acceptingRequests}
+          onCheckedChange={(checked) => handleChange('acceptingRequests', checked)}
+          disabled={isSubmitting}
+        />
+      </div>
+
+      <Button type="submit" disabled={isSubmitting}>
+        {isSubmitting ? 'Creating venue...' : 'Create venue'}
+      </Button>
+    </form>
+  )
+}

--- a/src/components/admin/admin-user-profile-form.tsx
+++ b/src/components/admin/admin-user-profile-form.tsx
@@ -1,0 +1,132 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+
+interface AdminUserProfileFormProps {
+  userId: string
+  name?: string | null
+  businessName?: string | null
+  phoneNumber?: string | null
+  adminLevel: 'support' | 'super_admin'
+}
+
+export function AdminUserProfileForm({
+  userId,
+  name,
+  businessName,
+  phoneNumber,
+  adminLevel,
+}: AdminUserProfileFormProps) {
+  const router = useRouter()
+  const isReadOnly = adminLevel !== 'super_admin'
+
+  const [formState, setFormState] = useState({
+    name: name || '',
+    businessName: businessName || '',
+    phoneNumber: phoneNumber || '',
+  })
+  const [isSaving, setIsSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+
+  const handleChange = (field: keyof typeof formState, value: string) => {
+    setFormState((prev) => ({ ...prev, [field]: value }))
+    setError(null)
+    setSuccess(null)
+  }
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault()
+
+    if (isReadOnly) return
+
+    setIsSaving(true)
+    setError(null)
+    setSuccess(null)
+
+    try {
+      const response = await fetch(`/api/admin/users/${userId}/profile`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(formState),
+      })
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}))
+        throw new Error(data.error || 'Failed to update profile')
+      }
+
+      setSuccess('Customer profile updated successfully')
+      router.refresh()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update profile')
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      {isReadOnly && (
+        <Alert>
+          <AlertDescription>
+            Support admins can review profile information. Editing profile details requires a super admin.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {error && (
+        <Alert variant="destructive">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      {success && (
+        <Alert>
+          <AlertDescription>{success}</AlertDescription>
+        </Alert>
+      )}
+
+      <div className="space-y-2">
+        <Label htmlFor="admin-customer-name">Customer Name</Label>
+        <Input
+          id="admin-customer-name"
+          value={formState.name}
+          onChange={(event) => handleChange('name', event.target.value)}
+          disabled={isReadOnly || isSaving}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="admin-customer-business">Business Name</Label>
+        <Input
+          id="admin-customer-business"
+          value={formState.businessName}
+          onChange={(event) => handleChange('businessName', event.target.value)}
+          disabled={isReadOnly || isSaving}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="admin-customer-phone">Phone Number</Label>
+        <Input
+          id="admin-customer-phone"
+          value={formState.phoneNumber}
+          onChange={(event) => handleChange('phoneNumber', event.target.value)}
+          disabled={isReadOnly || isSaving}
+        />
+      </div>
+
+      <Button type="submit" disabled={isReadOnly || isSaving}>
+        {isSaving ? 'Saving...' : 'Save profile changes'}
+      </Button>
+    </form>
+  )
+}

--- a/src/components/admin/admin-venue-editor.tsx
+++ b/src/components/admin/admin-venue-editor.tsx
@@ -1,0 +1,243 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Switch } from '@/components/ui/switch'
+
+interface AdminVenueEditorProps {
+  venue: {
+    id: string
+    name: string
+    urlName: string
+    acceptingRequests: boolean
+    address?: string | null
+    city?: string | null
+    state?: string | null
+    stateCode?: string | null
+    postalCode?: string | null
+    phoneNumber?: string | null
+    website?: string | null
+    createdAt: Date
+    updatedAt: Date
+  }
+  adminLevel: 'support' | 'super_admin'
+}
+
+export function AdminVenueEditor({ venue, adminLevel }: AdminVenueEditorProps) {
+  const router = useRouter()
+  const isReadOnly = adminLevel !== 'super_admin'
+
+  const [formState, setFormState] = useState({
+    name: venue.name,
+    address: venue.address || '',
+    city: venue.city || '',
+    state: venue.state || '',
+    stateCode: venue.stateCode || '',
+    postalCode: venue.postalCode || '',
+    phoneNumber: venue.phoneNumber || '',
+    website: venue.website || '',
+    acceptingRequests: venue.acceptingRequests,
+  })
+  const [isSaving, setIsSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+
+  const handleChange = (field: string, value: string | boolean) => {
+    setFormState((prev) => ({ ...prev, [field]: value }))
+    setError(null)
+    setSuccess(null)
+  }
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault()
+
+    if (isReadOnly) return
+
+    setIsSaving(true)
+    setError(null)
+    setSuccess(null)
+
+    try {
+      const response = await fetch(`/api/admin/venues/${venue.id}`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(formState),
+      })
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}))
+        throw new Error(data.error || 'Failed to update venue')
+      }
+
+      setSuccess('Venue details updated successfully')
+      router.refresh()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update venue')
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  const handleDelete = async () => {
+    if (isReadOnly) return
+
+    const confirmation = window.confirm(
+      'Are you sure you want to permanently delete this venue? This action cannot be undone.'
+    )
+
+    if (!confirmation) {
+      return
+    }
+
+    setIsSaving(true)
+    setError(null)
+    setSuccess(null)
+
+    try {
+      const response = await fetch(`/api/admin/venues/${venue.id}`, {
+        method: 'DELETE',
+      })
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}))
+        throw new Error(data.error || 'Failed to delete venue')
+      }
+
+      setSuccess('Venue deleted')
+      router.refresh()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to delete venue')
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      {error && (
+        <Alert variant="destructive">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      {success && (
+        <Alert>
+          <AlertDescription>{success}</AlertDescription>
+        </Alert>
+      )}
+
+      {isReadOnly && (
+        <Alert>
+          <AlertDescription>
+            Support-level admins can review venue details but only super admins can modify them.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="space-y-2">
+          <Label htmlFor={`venue-name-${venue.id}`}>Display Name</Label>
+          <Input
+            id={`venue-name-${venue.id}`}
+            value={formState.name}
+            onChange={(event) => handleChange('name', event.target.value)}
+            disabled={isReadOnly || isSaving}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor={`venue-phone-${venue.id}`}>Phone</Label>
+          <Input
+            id={`venue-phone-${venue.id}`}
+            value={formState.phoneNumber}
+            onChange={(event) => handleChange('phoneNumber', event.target.value)}
+            disabled={isReadOnly || isSaving}
+          />
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor={`venue-address-${venue.id}`}>Address</Label>
+        <Input
+          id={`venue-address-${venue.id}`}
+          value={formState.address}
+          onChange={(event) => handleChange('address', event.target.value)}
+          disabled={isReadOnly || isSaving}
+        />
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-3">
+        <div className="space-y-2">
+          <Label htmlFor={`venue-city-${venue.id}`}>City</Label>
+          <Input
+            id={`venue-city-${venue.id}`}
+            value={formState.city}
+            onChange={(event) => handleChange('city', event.target.value)}
+            disabled={isReadOnly || isSaving}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor={`venue-state-${venue.id}`}>State</Label>
+          <Input
+            id={`venue-state-${venue.id}`}
+            value={formState.state}
+            onChange={(event) => handleChange('state', event.target.value)}
+            disabled={isReadOnly || isSaving}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor={`venue-postal-${venue.id}`}>Postal Code</Label>
+          <Input
+            id={`venue-postal-${venue.id}`}
+            value={formState.postalCode}
+            onChange={(event) => handleChange('postalCode', event.target.value)}
+            disabled={isReadOnly || isSaving}
+          />
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor={`venue-website-${venue.id}`}>Website</Label>
+        <Input
+          id={`venue-website-${venue.id}`}
+          value={formState.website}
+          onChange={(event) => handleChange('website', event.target.value)}
+          disabled={isReadOnly || isSaving}
+        />
+      </div>
+
+      <div className="flex items-center justify-between rounded-md border p-3">
+        <div>
+          <Label className="text-sm font-medium">Accepting Requests</Label>
+          <p className="text-xs text-muted-foreground">
+            Toggle whether this venue is currently collecting song requests.
+          </p>
+        </div>
+        <Switch
+          checked={formState.acceptingRequests}
+          onCheckedChange={(checked) => handleChange('acceptingRequests', checked)}
+          disabled={isReadOnly || isSaving}
+        />
+      </div>
+
+      <div className="flex flex-wrap gap-3">
+        <Button type="submit" disabled={isReadOnly || isSaving}>
+          {isSaving ? 'Saving...' : 'Save changes'}
+        </Button>
+        <Button
+          type="button"
+          variant="destructive"
+          onClick={handleDelete}
+          disabled={isReadOnly || isSaving}
+        >
+          Delete venue
+        </Button>
+      </div>
+    </form>
+  )
+}

--- a/src/lib/admin-auth.ts
+++ b/src/lib/admin-auth.ts
@@ -1,0 +1,43 @@
+import { redirect } from 'next/navigation'
+import { getAuthSession } from '@/lib/auth-server'
+
+export type AdminLevel = 'support' | 'super_admin'
+
+export async function getAdminSession() {
+  const session = await getAuthSession()
+
+  if (!session?.user || session.user.accountType !== 'admin') {
+    return null
+  }
+
+  return session
+}
+
+export async function requireAdminSession(requiredLevel: AdminLevel = 'support') {
+  const session = await getAuthSession()
+
+  if (!session?.user || session.user.accountType !== 'admin') {
+    redirect('/auth/signin')
+  }
+
+  if (requiredLevel === 'super_admin' && session.user.adminLevel !== 'super_admin') {
+    redirect('/admin')
+  }
+
+  return session
+}
+
+export function assertAdminLevel(
+  session: Awaited<ReturnType<typeof getAdminSession>>,
+  requiredLevel: AdminLevel = 'support'
+) {
+  if (!session?.user || session.user.accountType !== 'admin') {
+    return false
+  }
+
+  if (requiredLevel === 'super_admin') {
+    return session.user.adminLevel === 'super_admin'
+  }
+
+  return true
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -5,6 +5,7 @@ import GoogleProvider from 'next-auth/providers/google'
 import { prisma } from '@/lib/prisma'
 import bcrypt from 'bcryptjs'
 import { z } from 'zod'
+import { logger } from '@/lib/logger'
 
 const loginSchema = z.object({
   email: z.string().email(),
@@ -46,21 +47,49 @@ export const authOptions: NextAuthOptions = {
             },
           })
 
-          if (!user || !user.passwordHash) {
+          if (user?.passwordHash) {
+            const isValidPassword = await bcrypt.compare(password, user.passwordHash)
+
+            if (!isValidPassword) {
+              return null
+            }
+
+            return {
+              id: user.id,
+              email: user.email,
+              name: user.name,
+              image: user.image,
+              accountType: 'customer' as const,
+            }
+          }
+
+          const adminUser = await prisma.adminUser.findUnique({
+            where: { email },
+            select: {
+              id: true,
+              email: true,
+              name: true,
+              passwordHash: true,
+              adminLevel: true,
+            },
+          })
+
+          if (!adminUser?.passwordHash) {
             return null
           }
 
-          const isValidPassword = await bcrypt.compare(password, user.passwordHash)
+          const isValidAdminPassword = await bcrypt.compare(password, adminUser.passwordHash)
 
-          if (!isValidPassword) {
+          if (!isValidAdminPassword) {
             return null
           }
 
           return {
-            id: user.id,
-            email: user.email,
-            name: user.name,
-            image: user.image,
+            id: adminUser.id,
+            email: adminUser.email,
+            name: adminUser.name,
+            accountType: 'admin' as const,
+            adminLevel: adminUser.adminLevel,
           }
         } catch {
           return null
@@ -69,15 +98,41 @@ export const authOptions: NextAuthOptions = {
     }),
   ],
   callbacks: {
-    async jwt({ token, user, account }) {
+    async jwt({ token, user }) {
       if (user) {
-        token.id = user.id
+        const accountType = (user as any).accountType ?? 'customer'
+        token.accountType = accountType
+
+        if (accountType === 'admin') {
+          token.adminId = user.id
+          token.adminLevel = (user as any).adminLevel
+          token.userId = null
+          token.id = user.id
+        } else {
+          token.userId = user.id
+          token.adminId = null
+          token.adminLevel = null
+          token.id = user.id
+        }
       }
       return token
     },
     async session({ session, token }) {
       if (token && session.user) {
-        session.user.id = token.id as string
+        const accountType = (token.accountType as string) ?? 'customer'
+        session.user.accountType = accountType as any
+
+        if (accountType === 'admin') {
+          session.user.id = (token.adminId as string) ?? (token.id as string)
+          session.user.adminLevel = token.adminLevel as any
+          session.user.adminId = token.adminId as string | undefined
+        } else {
+          session.user.id = (token.userId as string) ?? (token.id as string)
+          session.user.adminLevel = undefined
+          session.user.adminId = undefined
+        }
+
+        session.user.userId = token.userId as string | undefined
       }
       return session
     },

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -1,0 +1,27 @@
+import { DefaultSession } from 'next-auth'
+
+declare module 'next-auth' {
+  interface Session {
+    user?: DefaultSession['user'] & {
+      id: string
+      accountType?: 'customer' | 'admin'
+      adminLevel?: 'support' | 'super_admin'
+      adminId?: string
+      userId?: string
+    }
+  }
+
+  interface User {
+    accountType?: 'customer' | 'admin'
+    adminLevel?: 'support' | 'super_admin'
+  }
+}
+
+declare module 'next-auth/jwt' {
+  interface JWT {
+    accountType?: 'customer' | 'admin'
+    adminLevel?: 'support' | 'super_admin' | null
+    adminId?: string | null
+    userId?: string | null
+  }
+}


### PR DESCRIPTION
## Summary
- add dedicated admin layout with customer directory, global activity, and per-customer management views
- extend authentication to recognize admin accounts and expose admin session helpers/types
- add admin API endpoints and client tooling to create venues, manage API keys, and update customer details

## Testing
- npm run type-check *(fails: existing type errors in prisma seed data and tooling scripts)*

------
https://chatgpt.com/codex/tasks/task_e_68e54aca9fb88330bbe2e7fe37e80648