### PR TITLE
Add system management UI and align OpenKJ API with new schema

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -45,6 +45,8 @@ model User {
   customer      Customer?
   sessions      Session[]
   songDb        SongDb[]
+  systems       System[]
+  state         State?
   subscriptions Subscription[]
   venues        Venue[]        @relation("UserVenues")
 
@@ -279,6 +281,7 @@ model Venue {
   openKjVenueId     Int      @default(autoincrement()) @map("openkj_venue_id")
   urlName           String   @map("urlname")
   acceptingRequests Boolean  @default(true) @map("acceptingrequests")
+  accepting         Boolean  @default(false)
   hereplaceid       String?  @unique(map: "idx_venues_hereplaceid")
   name              String
   address           String?
@@ -294,10 +297,10 @@ model Venue {
   longitude         Float?
   createdAt         DateTime @default(now()) @map("createdat") @db.Timestamptz(6)
   updatedAt         DateTime @default(now()) @updatedAt @map("updatedat") @db.Timestamptz(6)
+  currentSystemId   Int      @default(1) @map("current_system_id")
 
   // relations
   requests Request[]
-  states   State[]
   user     User      @relation("UserVenues", fields: [userId], references: [id], onDelete: Cascade)
 
   // back-relations from singer_* tables
@@ -319,23 +322,18 @@ model Venue {
 }
 
 model State {
-  venueId   String   @map("venueid") @db.Uuid
-  systemId  Int      @default(0) @map("system_id")
-  accepting Boolean  @default(false)
-  serial    Int      @default(1)
-  createdAt DateTime @default(now()) @map("createdat") @db.Timestamptz(6)
-  updatedAt DateTime @default(now()) @updatedAt @map("updatedat") @db.Timestamptz(6)
+  userId String  @id @map("userid") @db.Uuid
+  serial BigInt  @default(1)
 
-  venue Venue @relation(fields: [venueId], references: [id], onDelete: Cascade)
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-  @@id([venueId, systemId])
   @@map("state")
 }
 
 model SongDb {
   songId             BigInt   @id @default(autoincrement()) @map("song_id")
   userId             String   @map("user_id") @db.Uuid
-  systemId           Int      @default(0) @map("system_id")
+  openKjSystemId     Int      @map("openkj_system_id")
   artist             String   @db.VarChar(255)
   title              String   @db.VarChar(255)
   combined           String   @db.VarChar(255)
@@ -345,18 +343,17 @@ model SongDb {
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-  @@unique([userId, systemId, combined], map: "songdb_user_id_system_id_combined_key")
-  @@unique([userId, systemId, normalizedCombined], map: "songdb_user_id_system_id_normalized_combined_key")
-  @@index([userId, systemId, artist], map: "idx_songdb_user_system_artist")
-  @@index([userId, systemId, title], map: "idx_songdb_user_system_title")
-  @@index([userId, systemId, normalizedCombined], map: "idx_songdb_user_system_normcombined")
+  @@unique([userId, openKjSystemId, combined], map: "songdb_user_id_system_id_combined_key")
+  @@unique([userId, openKjSystemId, normalizedCombined], map: "songdb_user_id_system_id_normalized_combined_key")
+  @@index([userId, openKjSystemId, artist], map: "idx_songdb_user_system_artist")
+  @@index([userId, openKjSystemId, title], map: "idx_songdb_user_system_title")
+  @@index([userId, openKjSystemId, normalizedCombined], map: "idx_songdb_user_system_normcombined")
   @@map("songdb")
 }
 
 model Request {
   requestId BigInt   @id @default(autoincrement()) @map("request_id")
   venueId   String   @map("venueid") @db.Uuid
-  systemId  Int      @default(0) @map("system_id")
   artist    String
   title     String
   singer    String?
@@ -374,6 +371,21 @@ model Request {
   singerUser SingerUser? @relation(fields: [singerId], references: [id], onDelete: Cascade)
 
   @@map("requests")
+}
+
+model System {
+  id             String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  userId         String   @map("user_id") @db.Uuid
+  openKjSystemId Int      @default(dbgenerated()) @map("openkj_system_id")
+  name           String
+  createdAt      DateTime @default(now()) @map("createdat") @db.Timestamptz(6)
+  updatedAt      DateTime @default(now()) @updatedAt @map("updatedat") @db.Timestamptz(6)
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, openKjSystemId], map: "systems_user_id_openkj_system_id_key")
+  @@index([userId, openKjSystemId], map: "systems_user_openkj_idx")
+  @@map("systems")
 }
 
 /**

--- a/src/app/admin/activity/page.tsx
+++ b/src/app/admin/activity/page.tsx
@@ -85,7 +85,7 @@ export default async function AdminActivityPage() {
         songId: true,
         artist: true,
         title: true,
-        systemId: true,
+        openKjSystemId: true,
         createdAt: true,
         user: {
           select: {
@@ -128,7 +128,7 @@ export default async function AdminActivityPage() {
       type: 'Catalog update',
       detail: `${song.artist} – ${song.title}`,
       account: song.user.name || song.user.email,
-      meta: `System ${song.systemId}`,
+      meta: `System ${song.openKjSystemId}`,
       timestamp: song.createdAt,
     })),
   ]

--- a/src/app/admin/users/[userId]/page.tsx
+++ b/src/app/admin/users/[userId]/page.tsx
@@ -104,7 +104,7 @@ export default async function AdminUserPage(props: PageProps<'/admin/users/[user
         songId: true,
         artist: true,
         title: true,
-        systemId: true,
+        openKjSystemId: true,
         createdAt: true,
       },
     }),
@@ -143,7 +143,7 @@ export default async function AdminUserPage(props: PageProps<'/admin/users/[user
       id: `song-${song.songId.toString()}`,
       type: 'Catalog update',
       detail: `${song.artist} – ${song.title}`,
-      meta: `System ${song.systemId}`,
+      meta: `System ${song.openKjSystemId}`,
       timestamp: song.createdAt,
     })),
     ...apiKeys.map((key) => ({
@@ -460,7 +460,7 @@ export default async function AdminUserPage(props: PageProps<'/admin/users/[user
                     <td className="px-4 py-2 font-medium">
                       {song.artist} – {song.title}
                     </td>
-                    <td className="px-4 py-2 text-muted-foreground">{song.systemId}</td>
+                    <td className="px-4 py-2 text-muted-foreground">{song.openKjSystemId}</td>
                     <td className="px-4 py-2 text-muted-foreground">
                       {formatDistanceToNow(song.createdAt, { addSuffix: true })}
                     </td>

--- a/src/app/api/admin/users/[userId]/venues/route.ts
+++ b/src/app/api/admin/users/[userId]/venues/route.ts
@@ -114,6 +114,7 @@ export async function POST(
         name: validatedData.name,
         urlName: validatedData.urlName,
         acceptingRequests: validatedData.acceptingRequests,
+        accepting: validatedData.acceptingRequests,
         address: validatedData.address,
         city: validatedData.city,
         state: validatedData.state,
@@ -128,13 +129,10 @@ export async function POST(
       },
     })
 
-    await prisma.state.create({
-      data: {
-        venueId: venue.id,
-        systemId: 0,
-        accepting: validatedData.acceptingRequests,
-        serial: 1,
-      },
+    await prisma.state.upsert({
+      where: { userId },
+      update: {},
+      create: { userId, serial: BigInt(1) },
     })
 
     logger.info('Admin created venue on behalf of user', {

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -58,13 +58,27 @@ export async function POST(request: NextRequest) {
       },
     })
 
-    // Create customer record
-    await prisma.customer.create({
-      data: {
-        id: user.id,
-        stripeCustomerId: customer.id,
-      },
-    })
+    // Create customer record and initialize default resources
+    await prisma.$transaction([
+      prisma.customer.create({
+        data: {
+          id: user.id,
+          stripeCustomerId: customer.id,
+        },
+      }),
+      prisma.system.create({
+        data: {
+          userId: user.id,
+          name: 'Main System',
+        },
+      }),
+      prisma.state.create({
+        data: {
+          userId: user.id,
+          serial: BigInt(1),
+        },
+      }),
+    ])
 
     return NextResponse.json(
       { 

--- a/src/app/api/systems/[id]/route.ts
+++ b/src/app/api/systems/[id]/route.ts
@@ -1,0 +1,107 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth/next'
+import { authOptions } from '@/lib/auth'
+import { prisma } from '@/lib/prisma'
+import { z } from 'zod'
+
+export const runtime = 'nodejs'
+
+const updateSystemSchema = z.object({
+  name: z.string().min(1, 'Name is required').max(100, 'Name must be 100 characters or fewer'),
+})
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await getServerSession(authOptions)
+  const { id } = await params
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  try {
+    const body = await request.json()
+    const { name } = updateSystemSchema.parse(body)
+
+    const system = await prisma.system.findFirst({
+      where: { id, userId: session.user.id },
+    })
+
+    if (!system) {
+      return NextResponse.json({ error: 'System not found' }, { status: 404 })
+    }
+
+    const updated = await prisma.system.update({
+      where: { id: system.id },
+      data: { name },
+    })
+
+    await prisma.state.upsert({
+      where: { userId: session.user.id },
+      update: { serial: { increment: BigInt(1) } },
+      create: { userId: session.user.id, serial: BigInt(1) },
+    })
+
+    return NextResponse.json({ system: updated })
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ error: error.errors[0].message }, { status: 400 })
+    }
+
+    console.error('Failed to update system', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await getServerSession(authOptions)
+  const { id } = await params
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  try {
+    const system = await prisma.system.findFirst({
+      where: { id, userId: session.user.id },
+    })
+
+    if (!system) {
+      return NextResponse.json({ error: 'System not found' }, { status: 404 })
+    }
+
+    const lastSystem = await prisma.system.findFirst({
+      where: { userId: session.user.id },
+      orderBy: { openKjSystemId: 'desc' },
+    })
+
+    if (!lastSystem || lastSystem.id !== system.id) {
+      return NextResponse.json(
+        { error: 'Systems must be deleted in descending order of their OpenKJ ID' },
+        { status: 400 }
+      )
+    }
+
+    await prisma.$transaction([
+      prisma.songDb.deleteMany({
+        where: { userId: session.user.id, openKjSystemId: system.openKjSystemId },
+      }),
+      prisma.system.delete({ where: { id: system.id } }),
+      prisma.state.upsert({
+        where: { userId: session.user.id },
+        update: { serial: { increment: BigInt(1) } },
+        create: { userId: session.user.id, serial: BigInt(1) },
+      }),
+    ])
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error('Failed to delete system', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/systems/route.ts
+++ b/src/app/api/systems/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth/next'
+import { authOptions } from '@/lib/auth'
+import { prisma } from '@/lib/prisma'
+import { z } from 'zod'
+
+export const runtime = 'nodejs'
+
+const createSystemSchema = z.object({
+  name: z.string().min(1, 'Name is required').max(100, 'Name must be 100 characters or fewer'),
+})
+
+export async function GET(request: NextRequest) {
+  const session = await getServerSession(authOptions)
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const systems = await prisma.system.findMany({
+    where: { userId: session.user.id },
+    orderBy: { openKjSystemId: 'asc' },
+  })
+
+  return NextResponse.json({ systems })
+}
+
+export async function POST(request: NextRequest) {
+  const session = await getServerSession(authOptions)
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  try {
+    const body = await request.json()
+    const { name } = createSystemSchema.parse(body)
+
+    const system = await prisma.system.create({
+      data: {
+        userId: session.user.id,
+        name,
+      },
+    })
+
+    await prisma.state.upsert({
+      where: { userId: session.user.id },
+      update: { serial: { increment: BigInt(1) } },
+      create: { userId: session.user.id, serial: BigInt(1) },
+    })
+
+    return NextResponse.json({ system })
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ error: error.errors[0].message }, { status: 400 })
+    }
+
+    console.error('Failed to create system', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/venues/route.ts
+++ b/src/app/api/venues/route.ts
@@ -100,6 +100,7 @@ export async function POST(request: NextRequest) {
         name: validatedData.name,
         urlName: validatedData.urlName,
         acceptingRequests: validatedData.acceptingRequests,
+        accepting: validatedData.acceptingRequests,
         hereplaceid: validatedData.herePlaceId,
         address: validatedData.address,
         city: validatedData.city,
@@ -115,14 +116,10 @@ export async function POST(request: NextRequest) {
       },
     })
 
-    // Initialize state for the venue
-    await prisma.state.create({
-      data: {
-        venueId: venue.id,
-        systemId: 0,
-        accepting: validatedData.acceptingRequests,
-        serial: 1,
-      },
+    await prisma.state.upsert({
+      where: { userId: session.user.id },
+      update: {},
+      create: { userId: session.user.id, serial: BigInt(1) },
     })
 
     return NextResponse.json({

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -90,24 +90,17 @@ async function updateApiKeysAndVenues(customerId: string, suspend: boolean) {
       // Set all venues to not accepting requests when subscription lapses
       await prisma.venue.updateMany({
         where: { userId: customer.user.id },
-        data: { 
+        data: {
           acceptingRequests: false,
+          accepting: false,
           updatedAt: new Date(),
         },
       })
 
-      // Update venue states
-      await prisma.state.updateMany({
-        where: {
-          venue: {
-            userId: customer.user.id,
-          }
-        },
-        data: {
-          accepting: false,
-          serial: { increment: 1 },
-          updatedAt: new Date(),
-        },
+      await prisma.state.upsert({
+        where: { userId: customer.user.id },
+        update: { serial: { increment: BigInt(1) } },
+        create: { userId: customer.user.id, serial: BigInt(1) },
       })
     }
     

--- a/src/app/dashboard/systems/page.tsx
+++ b/src/app/dashboard/systems/page.tsx
@@ -1,0 +1,42 @@
+import { redirect } from 'next/navigation'
+import { getServerSession } from 'next-auth/next'
+import { authOptions } from '@/lib/auth'
+import { prisma } from '@/lib/prisma'
+import { SystemsManager, SystemSummary } from '@/components/systems-manager'
+
+export const runtime = 'nodejs'
+
+export default async function SystemsPage() {
+  const session = await getServerSession(authOptions)
+
+  if (!session?.user?.id) {
+    redirect('/auth/signin')
+  }
+
+  const systems = await prisma.system.findMany({
+    where: { userId: session.user.id },
+    orderBy: { openKjSystemId: 'asc' },
+  })
+
+  const serializedSystems: SystemSummary[] = systems.map((system) => ({
+    id: system.id,
+    name: system.name,
+    openKjSystemId: system.openKjSystemId,
+    createdAt: system.createdAt.toISOString(),
+    updatedAt: system.updatedAt.toISOString(),
+  }))
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold">Systems</h1>
+        <p className="text-muted-foreground">
+          Manage the OpenKJ systems associated with your Singr account. Each system receives a
+          unique, gapless ID used for songbook synchronization.
+        </p>
+      </div>
+
+      <SystemsManager initialSystems={serializedSystems} />
+    </div>
+  )
+}

--- a/src/components/dashboard-nav.tsx
+++ b/src/components/dashboard-nav.tsx
@@ -8,6 +8,7 @@ const navigation = [
   { name: 'Dashboard', href: '/dashboard' },
   { name: 'Venues', href: '/dashboard/venues' },
   { name: 'API Keys', href: '/dashboard/api-keys' },
+  { name: 'Systems', href: '/dashboard/systems' },
   { name: 'Song Database', href: '/dashboard/songs' },
   { name: 'Requests', href: '/dashboard/requests' },
   { name: 'Billing', href: '/dashboard/billing' },

--- a/src/components/systems-manager.tsx
+++ b/src/components/systems-manager.tsx
@@ -1,0 +1,261 @@
+'use client'
+
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Badge } from '@/components/ui/badge'
+
+export type SystemSummary = {
+  id: string
+  name: string
+  openKjSystemId: number
+  createdAt: string
+  updatedAt: string
+}
+
+type Props = {
+  initialSystems: SystemSummary[]
+}
+
+export function SystemsManager({ initialSystems }: Props) {
+  const [systems, setSystems] = useState<SystemSummary[]>(initialSystems)
+  const [newName, setNewName] = useState('')
+  const [createError, setCreateError] = useState<string | null>(null)
+  const [createLoading, setCreateLoading] = useState(false)
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [editingName, setEditingName] = useState('')
+  const [editError, setEditError] = useState<string | null>(null)
+  const [deleteError, setDeleteError] = useState<string | null>(null)
+  const [deleteLoadingId, setDeleteLoadingId] = useState<string | null>(null)
+
+  const maxSystemId = systems.reduce((max, system) => Math.max(max, system.openKjSystemId), 0)
+
+  async function handleCreate(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    if (!newName.trim()) {
+      setCreateError('Please provide a system name')
+      return
+    }
+
+    setCreateLoading(true)
+    setCreateError(null)
+
+    try {
+      const response = await fetch('/api/systems', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: newName.trim() }),
+      })
+
+      const data = await response.json()
+      if (!response.ok) {
+        setCreateError(data.error ?? 'Failed to create system')
+        return
+      }
+
+      setSystems((prev) =>
+        [...prev, data.system].sort((a, b) => a.openKjSystemId - b.openKjSystemId),
+      )
+      setNewName('')
+    } catch (error) {
+      console.error('Failed to create system', error)
+      setCreateError('Unexpected error creating system')
+    } finally {
+      setCreateLoading(false)
+    }
+  }
+
+  function startEditing(system: SystemSummary) {
+    setEditingId(system.id)
+    setEditingName(system.name)
+    setEditError(null)
+  }
+
+  function cancelEditing() {
+    setEditingId(null)
+    setEditingName('')
+    setEditError(null)
+  }
+
+  async function handleRename(systemId: string) {
+    if (!editingName.trim()) {
+      setEditError('Name cannot be empty')
+      return
+    }
+
+    setEditError(null)
+
+    try {
+      const response = await fetch(`/api/systems/${systemId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: editingName.trim() }),
+      })
+
+      const data = await response.json()
+      if (!response.ok) {
+        setEditError(data.error ?? 'Failed to update system')
+        return
+      }
+
+      setSystems((prev) =>
+        prev.map((system) =>
+          system.id === systemId ? { ...system, name: data.system.name } : system,
+        ),
+      )
+      setEditingId(null)
+      setEditingName('')
+    } catch (error) {
+      console.error('Failed to update system', error)
+      setEditError('Unexpected error updating system')
+    }
+  }
+
+  async function handleDelete(systemId: string) {
+    setDeleteError(null)
+    setDeleteLoadingId(systemId)
+
+    try {
+      const response = await fetch(`/api/systems/${systemId}`, {
+        method: 'DELETE',
+      })
+      const data = await response.json()
+      if (!response.ok) {
+        setDeleteError(data.error ?? 'Failed to delete system')
+        return
+      }
+
+      setSystems((prev) => prev.filter((system) => system.id !== systemId))
+    } catch (error) {
+      console.error('Failed to delete system', error)
+      setDeleteError('Unexpected error deleting system')
+    } finally {
+      setDeleteLoadingId(null)
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Add a system</CardTitle>
+          <CardDescription>
+            Systems are numbered automatically and must remain gapless. Creating a new system
+            increments the next available OpenKJ system ID for your account.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleCreate} className="flex flex-col gap-3 sm:flex-row sm:items-center">
+            <Input
+              value={newName}
+              onChange={(event) => setNewName(event.target.value)}
+              placeholder="Enter system name"
+              className="sm:max-w-xs"
+              required
+            />
+            <Button type="submit" disabled={createLoading}>
+              {createLoading ? 'Creating…' : 'Create system'}
+            </Button>
+          </form>
+          {createError && (
+            <Alert variant="destructive" className="mt-4">
+              <AlertDescription>{createError}</AlertDescription>
+            </Alert>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Your systems</CardTitle>
+          <CardDescription>
+            Rename systems or remove the last system in the list. Deleting a system clears its songs from the Song DB.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {systems.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No systems available yet.</p>
+          ) : (
+            systems.map((system) => {
+              const isEditing = editingId === system.id
+              const canDelete = system.openKjSystemId === maxSystemId && systems.length > 1
+
+              return (
+                <div
+                  key={system.id}
+                  className="flex flex-col gap-4 rounded-md border p-4 sm:flex-row sm:items-center sm:justify-between"
+                >
+                  <div className="space-y-2">
+                    <div className="flex items-center gap-2">
+                      {isEditing ? (
+                        <Input
+                          value={editingName}
+                          onChange={(event) => setEditingName(event.target.value)}
+                          className="max-w-xs"
+                          autoFocus
+                        />
+                      ) : (
+                        <h3 className="text-lg font-semibold">{system.name}</h3>
+                      )}
+                      <Badge variant="outline">OpenKJ ID {system.openKjSystemId}</Badge>
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      Created {new Date(system.createdAt).toLocaleDateString()} • Updated{' '}
+                      {new Date(system.updatedAt).toLocaleDateString()}
+                    </p>
+                    {isEditing && editError && (
+                      <p className="text-sm text-destructive">{editError}</p>
+                    )}
+                  </div>
+
+                  <div className="flex flex-wrap items-center gap-2">
+                    {isEditing ? (
+                      <>
+                        <Button size="sm" onClick={() => handleRename(system.id)}>
+                          Save
+                        </Button>
+                        <Button size="sm" variant="outline" onClick={cancelEditing}>
+                          Cancel
+                        </Button>
+                      </>
+                    ) : (
+                      <Button size="sm" variant="outline" onClick={() => startEditing(system)}>
+                        Rename
+                      </Button>
+                    )}
+                    <Button
+                      size="sm"
+                      variant="destructive"
+                      disabled={!canDelete || deleteLoadingId === system.id}
+                      onClick={() => {
+                        if (!canDelete) return
+                        if (
+                          !window.confirm(
+                            'Deleting this system will remove all associated songs. Continue?',
+                          )
+                        ) {
+                          return
+                        }
+                        void handleDelete(system.id)
+                      }}
+                    >
+                      {deleteLoadingId === system.id ? 'Deleting…' : 'Delete'}
+                    </Button>
+                  </div>
+                </div>
+              )
+            })
+          )}
+
+          {deleteError && (
+            <Alert variant="destructive">
+              <AlertDescription>{deleteError}</AlertDescription>
+            </Alert>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add Prisma models for systems, simplified state rows, and updated venue/request/song schemas
- implement system management API endpoints, dashboard page, and client controls for creating, renaming, and deleting systems
- update OpenKJ API logic, signup flow, and supporting routes to use user-level serials, system validation, and new schema fields

## Testing
- `npx prisma generate`
- `npm run lint` *(fails: command prompts for interactive configuration in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e578d7b6848330871e78df193f247c