### PR TITLE
Add admin notes workspace and customer support tickets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ tsconfig.tsbuildinfo
 .env.sentry-build-plugin
 /logs/
 package-lock.json
+public/uploads/

--- a/src/app/admin/users/[userId]/notes/page.tsx
+++ b/src/app/admin/users/[userId]/notes/page.tsx
@@ -1,0 +1,116 @@
+export const runtime = 'nodejs'
+
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { ArrowLeft, NotebookPen } from 'lucide-react'
+import { format } from 'date-fns'
+import { PageProps } from 'next'
+
+import { requireAdminSession } from '@/lib/admin-auth'
+import { prisma } from '@/lib/prisma'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { AdminUserNotesForm } from '@/components/admin/admin-user-notes-form'
+import { AdminUserNotesTable } from '@/components/admin/admin-user-notes-table'
+
+export default async function AdminUserNotesPage(props: PageProps<'/admin/users/[userId]/notes'>) {
+  const paramsResolved = await props.params
+
+  await requireAdminSession()
+
+  const { userId } = paramsResolved
+
+  const [user, notes] = await Promise.all([
+    prisma.user.findUnique({
+      where: { id: userId },
+      select: {
+        id: true,
+        name: true,
+        email: true,
+        businessName: true,
+        createdAt: true,
+      },
+    }),
+    (prisma as any).userNote.findMany({
+      where: { userId },
+      include: {
+        author: {
+          select: {
+            name: true,
+            email: true,
+          },
+        },
+      },
+      orderBy: [
+        { important: 'desc' },
+        { createdAt: 'desc' },
+      ],
+    }),
+  ])
+
+  if (!user) {
+    notFound()
+  }
+
+  const preparedNotes = notes.map((note: any) => ({
+    id: note.id,
+    subject: note.subject,
+    note: note.note,
+    important: note.important,
+    createdAt: note.createdAt,
+    authorName: note.author?.name ?? note.author?.email ?? '',
+    authorEmail: note.author?.email,
+  }))
+
+  const noteCount = notes.length
+
+  return (
+    <div className="space-y-8">
+      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div className="flex flex-col gap-1">
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Button asChild variant="ghost" size="sm" className="-ml-3 h-auto px-3 py-1 text-muted-foreground">
+              <Link href={`/admin/users/${userId}`} className="inline-flex items-center gap-1">
+                <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+                Back to customer overview
+              </Link>
+            </Button>
+          </div>
+          <h1 className="flex items-center gap-2 text-3xl font-semibold">
+            <NotebookPen className="h-7 w-7 text-primary" aria-hidden="true" />
+            Customer notes
+          </h1>
+          <p className="text-muted-foreground">
+            {user.name || user.email} · Customer since {format(user.createdAt, 'MMM d, yyyy')}
+          </p>
+        </div>
+        <Badge variant="secondary" className="w-fit">
+          {noteCount} {noteCount === 1 ? 'note' : 'notes'} logged
+        </Badge>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
+        <Card className="order-last lg:order-first">
+          <CardHeader>
+            <CardTitle>Note history</CardTitle>
+            <CardDescription>Important context shared between support teammates.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <AdminUserNotesTable userId={userId} notes={preparedNotes} />
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Create a new note</CardTitle>
+            <CardDescription>Document conversations, escalations, or action items.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <AdminUserNotesForm userId={userId} />
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/src/app/admin/users/[userId]/page.tsx
+++ b/src/app/admin/users/[userId]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from 'next/navigation'
 import { requireAdminSession } from '@/lib/admin-auth'
 import { prisma } from '@/lib/prisma'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { AdminUserProfileForm } from '@/components/admin/admin-user-profile-form'
 import { AdminCreateVenueForm } from '@/components/admin/admin-create-venue-form'
@@ -12,7 +12,7 @@ import { Button } from '@/components/ui/button'
 import Link from 'next/link'
 import { formatDistanceToNow } from 'date-fns'
 import { Alert, AlertDescription } from '@/components/ui/alert'
-import { ArrowLeft } from 'lucide-react'
+import { ArrowLeft, ArrowUpRight, NotebookPen, Star } from 'lucide-react'
 import { PageProps } from 'next'
 
 interface AdminUserPageProps {
@@ -38,7 +38,7 @@ export default async function AdminUserPage(props: PageProps<'/admin/users/[user
   const adminLevel = session.user?.adminLevel ?? 'support'
   const { userId } = paramsResolved
 
-  const [user, venues, recentRequests, recentSongs] = await Promise.all([
+  const [user, venues, recentRequests, recentSongs, recentNotes] = await Promise.all([
     prisma.user.findUnique({
       where: { id: userId },
       include: {
@@ -109,6 +109,22 @@ export default async function AdminUserPage(props: PageProps<'/admin/users/[user
         createdAt: true,
       },
     }),
+    (prisma as any).userNote.findMany({
+      where: { userId },
+      include: {
+        author: {
+          select: {
+            name: true,
+            email: true,
+          },
+        },
+      },
+      orderBy: [
+        { important: 'desc' },
+        { createdAt: 'desc' },
+      ],
+      take: 5,
+    }),
   ])
 
   if (!user) {
@@ -120,6 +136,15 @@ export default async function AdminUserPage(props: PageProps<'/admin/users/[user
   const totalSongs = await prisma.songDb.count({ where: { userId } })
   const totalRequests = venues.reduce((acc, venue) => acc + venue._count.requests, 0)
   const primarySubscription = user.subscriptions[0]
+  const notesPreview = recentNotes.map((note) => ({
+    id: note.id,
+    subject: note.subject,
+    body: note.note.split('\n-----\n')[0] ?? note.note,
+    important: note.important,
+    createdAt: note.createdAt,
+    authorName: note.author?.name ?? note.author?.email ?? 'Support team',
+    authorEmail: note.author?.email,
+  }))
 
   const activityItems: ActivityItem[] = [
     ...venues.map((venue) => ({
@@ -154,7 +179,7 @@ export default async function AdminUserPage(props: PageProps<'/admin/users/[user
       meta: `Status: ${key.status}`,
       timestamp: key.createdAt,
     })),
-    ...user.subscriptions.map((sub) => ({
+    ...user.subscriptions.map((sub: any) => ({
       id: `subscription-${sub.id}`,
       type: 'Subscription',
       detail: `${sub.status}`,
@@ -220,6 +245,76 @@ export default async function AdminUserPage(props: PageProps<'/admin/users/[user
               <span className="font-semibold">{formatCount(apiKeys.length)}</span>
             </div>
           </CardContent>
+        </Card>
+      </section>
+
+      <section id="notes" className="grid gap-4 lg:grid-cols-[minmax(0,1fr)]">
+        <Card>
+          <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+            <div>
+              <CardTitle className="flex items-center gap-2 text-xl">
+                <NotebookPen className="h-5 w-5 text-primary" aria-hidden="true" />
+                Recent customer notes
+              </CardTitle>
+              <CardDescription>Internal-only notes shared across support and admin teammates.</CardDescription>
+            </div>
+            <Button asChild variant="ghost" className="h-9 gap-2 text-sm">
+              <Link href={`/admin/users/${userId}/notes`}>
+                Manage notes
+                <ArrowUpRight className="h-4 w-4" aria-hidden="true" />
+              </Link>
+            </Button>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {notesPreview.length ? (
+              <ul className="space-y-3">
+            {notesPreview.map((note: any) => {
+                  const trimmed = note.body.trim()
+                  const excerpt =
+                    trimmed.length > 260 ? `${trimmed.slice(0, 260).trimEnd()}…` : trimmed || '—'
+                  return (
+                    <li key={note.id}>
+                      <div
+                        className={`flex flex-col gap-2 rounded-lg border px-4 py-3 ${
+                          note.important
+                            ? 'border-amber-500/80 bg-amber-50/60'
+                            : 'border-border/60 bg-muted/40'
+                        }`}
+                      >
+                        <div className="flex flex-wrap items-center gap-2">
+                          <span className="font-semibold text-foreground">{note.subject}</span>
+                          {note.important ? (
+                            <Badge variant="secondary" className="inline-flex items-center gap-1 bg-amber-500/90 text-white">
+                              <Star className="h-3 w-3" aria-hidden="true" /> Important
+                            </Badge>
+                          ) : null}
+                        </div>
+                        <p className="whitespace-pre-line text-sm text-muted-foreground">{excerpt}</p>
+                        <div className="text-xs uppercase tracking-wide text-muted-foreground">
+                          {note.authorName}
+                          {' • '}
+                          {formatDistanceToNow(note.createdAt, { addSuffix: true })}
+                        </div>
+                      </div>
+                    </li>
+                  )
+                })}
+              </ul>
+            ) : (
+              <div className="rounded-md border border-dashed border-border/60 bg-muted/30 px-4 py-10 text-center text-sm text-muted-foreground">
+                No notes recorded for this customer yet. Use the notes workspace to capture context for future support
+                interactions.
+              </div>
+            )}
+          </CardContent>
+          <CardFooter>
+            <Button asChild variant="outline">
+              <Link href={`/admin/users/${userId}/notes`} className="inline-flex items-center gap-2">
+                View full notes workspace
+                <ArrowUpRight className="h-4 w-4" aria-hidden="true" />
+              </Link>
+            </Button>
+          </CardFooter>
         </Card>
       </section>
 
@@ -311,7 +406,7 @@ export default async function AdminUserPage(props: PageProps<'/admin/users/[user
         </Card>
 
         <div className="grid gap-6">
-          {venues.map((venue) => (
+          {venues.map((venue: any) => (
             <Card key={venue.id}>
               <CardHeader className="flex flex-col gap-1">
                 <div className="flex items-center justify-between">
@@ -373,7 +468,7 @@ export default async function AdminUserPage(props: PageProps<'/admin/users/[user
                 </tr>
               </thead>
               <tbody className="divide-y divide-slate-200 text-sm">
-                {apiKeys.map((key) => (
+          {apiKeys.map((key: any) => (
                   <tr key={key.id}>
                     <td className="px-4 py-2 font-medium">{key.description || '—'}</td>
                     <td className="px-4 py-2">
@@ -426,7 +521,7 @@ export default async function AdminUserPage(props: PageProps<'/admin/users/[user
                 </tr>
               </thead>
               <tbody className="divide-y divide-slate-200">
-                {recentRequests.map((request) => (
+          {recentRequests.map((request: any) => (
                   <tr key={request.requestId.toString()}>
                     <td className="px-4 py-2 font-medium">
                       {request.artist} – {request.title}
@@ -471,7 +566,7 @@ export default async function AdminUserPage(props: PageProps<'/admin/users/[user
                 </tr>
               </thead>
               <tbody className="divide-y divide-slate-200">
-                {recentSongs.map((song) => (
+          {recentSongs.map((song: any) => (
                   <tr key={song.songId.toString()}>
                     <td className="px-4 py-2 font-medium">
                       {song.artist} – {song.title}

--- a/src/app/api/admin/users/[userId]/notes/[noteId]/route.ts
+++ b/src/app/api/admin/users/[userId]/notes/[noteId]/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+
+import { getAdminSession, assertAdminLevel } from '@/lib/admin-auth'
+import { prisma } from '@/lib/prisma'
+import { logger } from '@/lib/logger'
+
+export const runtime = 'nodejs'
+
+const updateSchema = z.object({
+  important: z.boolean(),
+})
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ userId: string; noteId: string }> }
+) {
+  const paramsResolved = await params
+  const { userId, noteId } = paramsResolved
+
+  const session = await getAdminSession()
+
+  if (!assertAdminLevel(session, 'support')) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  try {
+    const body = await request.json()
+    const payload = updateSchema.parse(body)
+
+    const note = await (prisma as any).userNote.findUnique({
+      where: { id: noteId },
+      select: {
+        id: true,
+        userId: true,
+      },
+    })
+
+    if (!note || note.userId !== userId) {
+      return NextResponse.json({ error: 'Note not found' }, { status: 404 })
+    }
+
+    const updated = await (prisma as any).userNote.update({
+      where: { id: noteId },
+      data: { important: payload.important },
+    })
+
+    logger.info('Admin toggled customer note importance', {
+      adminId: session?.user?.adminId ?? session?.user?.id,
+      noteId,
+      targetUserId: userId,
+      important: payload.important,
+    })
+
+    return NextResponse.json({
+      id: updated.id,
+      important: updated.important,
+    })
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ error: error.errors[0]?.message ?? 'Invalid payload' }, { status: 400 })
+    }
+
+    logger.error('Failed to toggle customer note importance', {
+      error,
+      adminId: session?.user?.adminId ?? session?.user?.id,
+      noteId,
+      targetUserId: userId,
+    })
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/admin/users/[userId]/notes/route.ts
+++ b/src/app/api/admin/users/[userId]/notes/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+
+import { getAdminSession, assertAdminLevel } from '@/lib/admin-auth'
+import { prisma } from '@/lib/prisma'
+import { logger } from '@/lib/logger'
+
+export const runtime = 'nodejs'
+
+const createNoteSchema = z.object({
+  subject: z.string().min(1, 'Subject is required').max(200, 'Subject is too long'),
+  note: z.string().min(1, 'Note body is required'),
+  important: z.boolean().optional(),
+})
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ userId: string }> }
+) {
+  const paramsResolved = await params
+
+  const session = await getAdminSession()
+
+  if (!assertAdminLevel(session, 'support')) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const { userId } = paramsResolved
+
+  try {
+    const body = await request.json()
+    const payload = createNoteSchema.parse(body)
+
+    const customer = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { id: true },
+    })
+
+    if (!customer) {
+      return NextResponse.json({ error: 'Customer not found' }, { status: 404 })
+    }
+
+    const note = await (prisma as any).userNote.create({
+      data: {
+        userId,
+        createdBy: session!.user!.id,
+        important: payload.important ?? false,
+        subject: payload.subject,
+        note: payload.note,
+      },
+    })
+
+    logger.info('Admin saved customer note', {
+      adminId: session?.user?.adminId ?? session?.user?.id,
+      noteId: note.id,
+      targetUserId: userId,
+      important: note.important,
+    })
+
+    return NextResponse.json({
+      id: note.id,
+      important: note.important,
+    })
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ error: error.errors[0]?.message ?? 'Invalid payload' }, { status: 400 })
+    }
+
+    logger.error('Failed to create customer note', {
+      error,
+      adminId: session?.user?.adminId ?? session?.user?.id,
+      targetUserId: userId,
+    })
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/support/tickets/[ticketId]/messages/route.ts
+++ b/src/app/api/support/tickets/[ticketId]/messages/route.ts
@@ -1,0 +1,162 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { promises as fs } from 'fs'
+import path from 'path'
+import { format } from 'date-fns'
+
+import { getAuthSession } from '@/lib/auth-server'
+import { prisma } from '@/lib/prisma'
+import { logger } from '@/lib/logger'
+import {
+  persistSupportAttachment,
+  AttachmentValidationError,
+  SavedSupportAttachment,
+} from '@/lib/support-attachments'
+
+export const runtime = 'nodejs'
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ ticketId: string }> }
+) {
+  const paramsResolved = await params
+  const { ticketId } = paramsResolved
+
+  const session = await getAuthSession()
+
+  if (!session?.user?.id || session.user.accountType !== 'customer') {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const formData = await request.formData()
+  const body = formData.get('body')?.toString().trim()
+
+  if (!body) {
+    return NextResponse.json({ error: 'Message body is required' }, { status: 400 })
+  }
+
+  const ticket = await (prisma as any).supportTicket.findFirst({
+    where: {
+      id: ticketId,
+      requesterId: session.user.id,
+    },
+    include: {
+      messages: {
+        where: { visibility: 'public' },
+        include: {
+          author: {
+            select: {
+              id: true,
+              name: true,
+              email: true,
+            },
+          },
+        },
+        orderBy: { createdAt: 'desc' },
+        take: 10,
+      },
+    },
+  })
+
+  if (!ticket) {
+    return NextResponse.json({ error: 'Ticket not found' }, { status: 404 })
+  }
+
+  if (ticket.status === 'closed') {
+    return NextResponse.json({ error: 'This ticket is closed and cannot receive new messages.' }, { status: 400 })
+  }
+
+  const messageHistory = ticket.messages
+    .map((message) => {
+      const authorName =
+        message.author?.id === session.user!.id
+          ? 'You'
+          : message.author?.name || message.author?.email || 'Support team'
+      const timestamp = format(message.createdAt, 'MMM d, yyyy p')
+      return `On ${timestamp}, ${authorName} wrote:\n${message.body}`
+    })
+    .join('\n\n-----\n')
+
+  const attachments = formData
+    .getAll('attachments')
+    .filter((value): value is File => value instanceof File && value.size > 0)
+
+  try {
+    const result = await (prisma as any).$transaction(async (tx: any) => {
+      const message = await tx.supportTicketMessage.create({
+        data: {
+          ticketId,
+          authorId: session.user!.id,
+          visibility: 'public',
+          body: messageHistory ? `${body}\n\n-----\n${messageHistory}` : body,
+        },
+      })
+
+      const nextStatus =
+        ticket.status === 'pending_customer' || ticket.status === 'resolved'
+          ? 'pending_support'
+          : ticket.status
+
+      if (nextStatus !== ticket.status) {
+        await tx.supportTicket.update({
+          where: { id: ticketId },
+          data: { status: nextStatus },
+        })
+      }
+
+      if (attachments.length) {
+        const savedFiles: SavedSupportAttachment[] = []
+        try {
+          for (const file of attachments) {
+            const saved = await persistSupportAttachment(ticketId, file)
+            savedFiles.push(saved)
+          }
+
+          if (savedFiles.length) {
+            await tx.supportMessageAttachment.createMany({
+              data: savedFiles.map((file) => ({
+                messageId: message.id,
+                fileName: file.fileName,
+                mimeType: file.mimeType ?? null,
+                byteSize: BigInt(file.byteSize),
+                storageUrl: file.storageUrl,
+              })),
+            })
+          }
+        } catch (error) {
+          await Promise.all(
+            savedFiles.map(async (file) => {
+              const relativePath = file.storageUrl.replace(/^[\/]+/, '')
+              const absolutePath = path.join(process.cwd(), 'public', relativePath)
+              try {
+                await fs.unlink(absolutePath)
+              } catch {}
+            })
+          )
+          throw error
+        }
+      }
+
+      return message
+    })
+
+    logger.info('Customer replied to support ticket', {
+      ticketId,
+      requesterId: session.user.id,
+      messageId: result.id,
+    })
+
+    return NextResponse.json({ id: result.id })
+  } catch (error) {
+    if (error instanceof AttachmentValidationError) {
+      return NextResponse.json({ error: error.message }, { status: 400 })
+    }
+
+    logger.error('Failed to send ticket reply', {
+      ticketId,
+      requesterId: session.user.id,
+      error,
+    })
+
+    return NextResponse.json({ error: 'Unable to send message' }, { status: 500 })
+  }
+}

--- a/src/app/api/support/tickets/route.ts
+++ b/src/app/api/support/tickets/route.ts
@@ -1,0 +1,124 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { promises as fs } from 'fs'
+import path from 'path'
+
+import { getAuthSession } from '@/lib/auth-server'
+import { prisma } from '@/lib/prisma'
+import { logger } from '@/lib/logger'
+import {
+  persistSupportAttachment,
+  AttachmentValidationError,
+  SavedSupportAttachment,
+} from '@/lib/support-attachments'
+
+export const runtime = 'nodejs'
+
+const createTicketSchema = z.object({
+  subject: z.string().min(5, 'Subject must be at least 5 characters.'),
+  description: z.string().min(10, 'Description must be at least 10 characters.'),
+  priority: z.enum(['low', 'normal', 'high', 'urgent']).default('normal'),
+  category: z.string().optional(),
+})
+
+export async function POST(request: NextRequest) {
+  const session = await getAuthSession()
+
+  if (!session?.user?.id || session.user.accountType !== 'customer') {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const formData = await request.formData()
+
+  const payload = createTicketSchema.safeParse({
+    subject: formData.get('subject'),
+    description: formData.get('description'),
+    priority: (formData.get('priority') ?? 'normal').toString(),
+    category: formData.get('category')?.toString() || undefined,
+  })
+
+  if (!payload.success) {
+    return NextResponse.json({ error: payload.error.errors[0]?.message ?? 'Invalid request' }, { status: 400 })
+  }
+
+  const attachments = formData
+    .getAll('attachments')
+    .filter((value): value is File => value instanceof File && value.size > 0)
+
+  try {
+    const result = await (prisma as any).$transaction(async (tx: any) => {
+      const ticket = await tx.supportTicket.create({
+        data: {
+          requesterId: session.user!.id,
+          createdById: session.user!.id,
+          subject: payload.data.subject,
+          description: payload.data.description,
+          priority: payload.data.priority,
+          category: payload.data.category || null,
+        },
+      })
+
+      const message = await tx.supportTicketMessage.create({
+        data: {
+          ticketId: ticket.id,
+          authorId: session.user!.id,
+          visibility: 'public',
+          body: payload.data.description,
+        },
+      })
+
+      if (attachments.length) {
+        const savedFiles: SavedSupportAttachment[] = []
+        try {
+          for (const file of attachments) {
+            const saved = await persistSupportAttachment(ticket.id, file)
+            savedFiles.push(saved)
+          }
+
+          if (savedFiles.length) {
+            await tx.supportMessageAttachment.createMany({
+              data: savedFiles.map((file) => ({
+                messageId: message.id,
+                fileName: file.fileName,
+                mimeType: file.mimeType ?? null,
+                byteSize: BigInt(file.byteSize),
+                storageUrl: file.storageUrl,
+              })),
+            })
+          }
+        } catch (error) {
+          await Promise.all(
+            savedFiles.map(async (file) => {
+              const relativePath = file.storageUrl.replace(/^[\/]+/, '')
+              const absolutePath = path.join(process.cwd(), 'public', relativePath)
+              try {
+                await fs.unlink(absolutePath)
+              } catch {}
+            })
+          )
+          throw error
+        }
+      }
+
+      return ticket
+    })
+
+    logger.info('Customer created support ticket', {
+      ticketId: result.id,
+      requesterId: session.user.id,
+    })
+
+    return NextResponse.json({ id: result.id })
+  } catch (error) {
+    if (error instanceof AttachmentValidationError) {
+      return NextResponse.json({ error: error.message }, { status: 400 })
+    }
+
+    logger.error('Failed to create support ticket', {
+      error,
+      requesterId: session.user.id,
+    })
+
+    return NextResponse.json({ error: 'Unable to create support ticket' }, { status: 500 })
+  }
+}

--- a/src/app/dashboard/support/[ticketId]/page.tsx
+++ b/src/app/dashboard/support/[ticketId]/page.tsx
@@ -1,0 +1,189 @@
+export const runtime = 'nodejs'
+
+import { notFound, redirect } from 'next/navigation'
+import { format, formatDistanceToNow } from 'date-fns'
+import { ArrowLeft, MessageCirclePlus } from 'lucide-react'
+import Link from 'next/link'
+
+import { getAuthSession } from '@/lib/auth-server'
+import { prisma } from '@/lib/prisma'
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { SupportTicketStatusBadge } from '@/components/support/support-ticket-status-badge'
+import { SupportTicketPriorityBadge } from '@/components/support/support-ticket-priority-badge'
+import { SupportTicketMessageThread } from '@/components/support/support-ticket-message-thread'
+import { SupportTicketReplyForm } from '@/components/support/support-ticket-reply-form'
+
+type PageProps = {
+  params: Promise<{ ticketId: string }>
+}
+
+export default async function SupportTicketDetailPage({ params }: PageProps) {
+  const paramsResolved = await params
+  const { ticketId } = paramsResolved
+
+  const session = await getAuthSession()
+
+  if (!session?.user?.id) {
+    redirect('/auth/signin')
+  }
+
+  if (session.user.accountType && session.user.accountType !== 'customer') {
+    redirect('/admin')
+  }
+
+  const ticket = await (prisma as any).supportTicket.findFirst({
+    where: {
+      id: ticketId,
+      requesterId: session.user.id,
+    },
+    include: {
+      assignee: {
+        select: {
+          name: true,
+          email: true,
+        },
+      },
+      requester: {
+        select: {
+          name: true,
+          email: true,
+        },
+      },
+      creator: {
+        select: {
+          name: true,
+          email: true,
+        },
+      },
+    },
+  })
+
+  if (!ticket) {
+    notFound()
+  }
+
+  const messages = await (prisma as any).supportTicketMessage.findMany({
+    where: {
+      ticketId,
+      visibility: 'public',
+    },
+    include: {
+      author: {
+        select: {
+          id: true,
+          name: true,
+          email: true,
+        },
+      },
+      attachments: {
+        select: {
+          id: true,
+          fileName: true,
+          mimeType: true,
+          byteSize: true,
+          storageUrl: true,
+        },
+      },
+    },
+    orderBy: { createdAt: 'asc' },
+  })
+
+  const isClosed = ticket.status === 'closed'
+  const openedAt = format(ticket.createdAt, 'MMM d, yyyy p')
+  const lastUpdated = formatDistanceToNow(ticket.updatedAt, { addSuffix: true })
+  const assignee = ticket.assignee?.name || ticket.assignee?.email || 'Unassigned'
+  const requester = ticket.requester?.name || ticket.requester?.email || 'You'
+
+  return (
+    <div className="space-y-8">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+        <Button asChild variant="ghost" className="w-fit gap-2 text-sm text-muted-foreground">
+          <Link href="/dashboard/support">
+            <ArrowLeft className="h-4 w-4" aria-hidden="true" /> Back to tickets
+          </Link>
+        </Button>
+        <div className="flex flex-wrap gap-2">
+          <SupportTicketStatusBadge status={ticket.status} />
+          <SupportTicketPriorityBadge priority={ticket.priority} />
+          {ticket.category ? <Badge variant="outline">{ticket.category}</Badge> : null}
+        </div>
+      </div>
+
+      <header className="space-y-2">
+        <h1 className="text-3xl font-bold break-words">{ticket.subject}</h1>
+        <p className="text-muted-foreground">
+          Ticket #{ticket.id.slice(0, 8)} • Opened {openedAt} • Last updated {lastUpdated}
+        </p>
+      </header>
+
+      {isClosed ? (
+        <Alert>
+          <AlertDescription>
+            This ticket has been closed. You can review past messages below or open a new ticket if you need further
+            assistance.
+          </AlertDescription>
+        </Alert>
+      ) : null}
+
+      <section className="grid gap-6 lg:grid-cols-[0.65fr_0.35fr]">
+        <Card className="order-last border border-border/70 lg:order-first">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <MessageCirclePlus className="h-5 w-5 text-primary" aria-hidden="true" /> Conversation
+            </CardTitle>
+            <CardDescription>All customer-visible messages and file attachments.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <SupportTicketMessageThread currentUserId={session.user.id} messages={messages} />
+            <div className="rounded-md border border-border/60 bg-muted/30 p-4 text-xs text-muted-foreground">
+              Internal notes from the support team are hidden from this view. Replies you send are always public to our team.
+            </div>
+          </CardContent>
+          <CardFooter>
+            <SupportTicketReplyForm ticketId={ticket.id} disabled={isClosed} />
+          </CardFooter>
+        </Card>
+
+        <Card className="border border-border/70 bg-muted/10">
+          <CardHeader>
+            <CardTitle>Ticket details</CardTitle>
+            <CardDescription>Key metadata to help you track this request.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4 text-sm">
+            <div className="flex flex-col gap-1">
+              <span className="text-xs uppercase tracking-wide text-muted-foreground">Requester</span>
+              <span className="font-medium text-foreground">{requester}</span>
+            </div>
+            <div className="flex flex-col gap-1">
+              <span className="text-xs uppercase tracking-wide text-muted-foreground">Assigned to</span>
+              <span className="font-medium text-foreground">{assignee}</span>
+            </div>
+            <div className="flex flex-col gap-1">
+              <span className="text-xs uppercase tracking-wide text-muted-foreground">Opened</span>
+              <span className="font-medium text-foreground">{openedAt}</span>
+            </div>
+            <div className="flex flex-col gap-1">
+              <span className="text-xs uppercase tracking-wide text-muted-foreground">Current status</span>
+              <span className="font-medium text-foreground capitalize">{ticket.status.replace('_', ' ')}</span>
+            </div>
+            {ticket.externalReference ? (
+              <div className="flex flex-col gap-1">
+                <span className="text-xs uppercase tracking-wide text-muted-foreground">External reference</span>
+                <span className="font-medium text-foreground">{ticket.externalReference}</span>
+              </div>
+            ) : null}
+          </CardContent>
+          <CardFooter>
+            <div className="text-xs text-muted-foreground">
+              Created by {ticket.creator?.name || ticket.creator?.email || 'Support'} on{' '}
+              {format(ticket.createdAt, 'MMM d, yyyy p')}.
+            </div>
+          </CardFooter>
+        </Card>
+      </section>
+    </div>
+  )
+}

--- a/src/app/dashboard/support/page.tsx
+++ b/src/app/dashboard/support/page.tsx
@@ -1,0 +1,196 @@
+export const runtime = 'nodejs'
+
+import { redirect } from 'next/navigation'
+import { LifeBuoy, Inbox, Clock, CheckCircle2, Archive, type LucideIcon } from 'lucide-react'
+
+import { getAuthSession } from '@/lib/auth-server'
+import { prisma } from '@/lib/prisma'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { SupportTicketCreateForm } from '@/components/support/support-ticket-create-form'
+import { SupportTicketList } from '@/components/support/support-ticket-list'
+import type { TicketStatus } from '@/components/support/support-ticket-status-badge'
+
+const STATUS_SUMMARY: Array<{
+  id: string
+  label: string
+  description: string
+  icon: LucideIcon
+  statuses: TicketStatus[]
+}> = [
+  {
+    id: 'open',
+    label: 'Open',
+    description: 'Newly created tickets awaiting triage.',
+    icon: LifeBuoy,
+    statuses: ['open'],
+  },
+  {
+    id: 'pending_support',
+    label: 'Waiting on support',
+    description: 'Our team is reviewing these tickets.',
+    icon: Inbox,
+    statuses: ['pending_support'],
+  },
+  {
+    id: 'pending_customer',
+    label: 'Waiting on you',
+    description: 'We need your reply to move forward.',
+    icon: Clock,
+    statuses: ['pending_customer'],
+  },
+  {
+    id: 'resolved',
+    label: 'Resolved',
+    description: 'Marked as solved but not yet archived.',
+    icon: CheckCircle2,
+    statuses: ['resolved'],
+  },
+  {
+    id: 'closed',
+    label: 'Closed',
+    description: 'Fully closed tickets for historical reference.',
+    icon: Archive,
+    statuses: ['closed'],
+  },
+]
+
+export default async function SupportDashboardPage() {
+  const session = await getAuthSession()
+
+  if (!session?.user?.id) {
+    redirect('/auth/signin')
+  }
+
+  if (session.user.accountType && session.user.accountType !== 'customer') {
+    redirect('/admin')
+  }
+
+  const userId = session.user.id
+
+  const [tickets, groupedCounts] = await Promise.all([
+    (prisma as any).supportTicket.findMany({
+      where: { requesterId: userId },
+      include: {
+        assignee: {
+          select: {
+            name: true,
+          },
+        },
+        _count: {
+          select: {
+            messages: true,
+          },
+        },
+        messages: {
+          where: { visibility: 'public' },
+          orderBy: { createdAt: 'desc' },
+          take: 1,
+          select: {
+            authorId: true,
+            createdAt: true,
+          },
+        },
+      },
+      orderBy: { updatedAt: 'desc' },
+    }),
+    (prisma as any).supportTicket.groupBy({
+      by: ['status'],
+      where: { requesterId: userId },
+      _count: {
+        _all: true,
+      },
+    }),
+  ])
+
+  const countByStatus = new Map<TicketStatus, number>(groupedCounts.map((item) => [item.status, item._count._all]))
+
+  const summaryCards = STATUS_SUMMARY.map((card) => ({
+    ...card,
+    value: card.statuses.reduce((total, status) => total + (countByStatus.get(status) ?? 0), 0),
+  }))
+
+  const ticketRows = tickets.map((ticket) => ({
+    id: ticket.id,
+    subject: ticket.subject,
+    status: ticket.status,
+    priority: ticket.priority,
+    createdAt: ticket.createdAt,
+    updatedAt: ticket.updatedAt,
+    messageCount: ticket._count.messages,
+    lastMessageAt: ticket.messages[0]?.createdAt ?? null,
+    lastMessageAuthorId: ticket.messages[0]?.authorId ?? null,
+    assigneeName: ticket.assignee?.name ?? null,
+  }))
+
+  return (
+    <div className="space-y-8">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-bold">Support center</h1>
+        <p className="text-muted-foreground">
+          Create new requests, review existing tickets, and collaborate with the Singr support team.
+        </p>
+      </header>
+
+      <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-5">
+        {summaryCards.map((card) => {
+          const Icon = card.icon
+          return (
+            <Card key={card.id} className="border border-dashed">
+              <CardHeader className="flex flex-row items-start justify-between space-y-0">
+                <div>
+                  <CardTitle className="text-sm font-medium text-muted-foreground">{card.label}</CardTitle>
+                  <CardDescription className="text-xs">{card.description}</CardDescription>
+                </div>
+                <Icon className="h-5 w-5 text-primary" aria-hidden="true" />
+              </CardHeader>
+              <CardContent>
+                <p className="text-3xl font-bold">{card.value}</p>
+              </CardContent>
+            </Card>
+          )
+        })}
+      </section>
+
+      <section className="grid gap-6 lg:grid-cols-[0.55fr_0.45fr]">
+        <Card className="order-last border border-border/70 lg:order-first">
+          <CardHeader>
+            <CardTitle>Submit a support request</CardTitle>
+            <CardDescription>
+              Provide as much detail as possible—attachments and clear descriptions help us respond quickly.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <SupportTicketCreateForm />
+          </CardContent>
+        </Card>
+
+        <Card className="border border-border/70 bg-muted/20">
+          <CardHeader>
+            <CardTitle>Need immediate help?</CardTitle>
+            <CardDescription>
+              Search our knowledge base or call the Singr support line for urgent production incidents.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm text-muted-foreground">
+            <p>
+              • Visit the <a href="https://support.singr.io" className="font-medium text-primary hover:underline">support
+              documentation</a> for setup guides, FAQs, and troubleshooting steps.
+            </p>
+            <p>• Call our emergency hotline at <span className="font-medium text-foreground">(800) 555-0199</span>.</p>
+            <p>• Email <span className="font-medium text-foreground">support@singr.io</span> for billing or account changes.</p>
+          </CardContent>
+        </Card>
+      </section>
+
+      <section className="space-y-4">
+        <div>
+          <h2 className="text-2xl font-semibold">Your tickets</h2>
+          <p className="text-sm text-muted-foreground">
+            Track the progress of open issues, follow up on pending conversations, and review past resolutions.
+          </p>
+        </div>
+        <SupportTicketList tickets={ticketRows} currentUserId={userId} />
+      </section>
+    </div>
+  )
+}

--- a/src/components/admin/admin-note-important-toggle.tsx
+++ b/src/components/admin/admin-note-important-toggle.tsx
@@ -1,0 +1,79 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import { Star, Loader2 } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { useToast } from '@/components/ui/use-toast'
+
+type AdminNoteImportantToggleProps = {
+  userId: string
+  noteId: string
+  important: boolean
+}
+
+export function AdminNoteImportantToggle({ userId, noteId, important }: AdminNoteImportantToggleProps) {
+  const router = useRouter()
+  const { toast } = useToast()
+  const [isPending, startTransition] = useTransition()
+  const [optimisticImportant, setOptimisticImportant] = useState(important)
+
+  const handleToggle = () => {
+    if (isPending) return
+
+    const nextValue = !optimisticImportant
+    setOptimisticImportant(nextValue)
+
+    startTransition(async () => {
+      try {
+        const response = await fetch(`/api/admin/users/${userId}/notes/${noteId}`, {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ important: nextValue }),
+        })
+
+        if (!response.ok) {
+          const payload = await response.json().catch(() => ({}))
+          throw new Error(payload.error ?? 'Unable to update note importance')
+        }
+
+        toast({
+          title: nextValue ? 'Marked as important' : 'Removed important flag',
+          description: nextValue
+            ? 'The note now appears at the top of the customer history.'
+            : 'The note will appear in chronological order.',
+        })
+        router.refresh()
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unable to update note'
+        setOptimisticImportant((prev) => !prev) // revert
+        toast({
+          variant: 'destructive',
+          title: 'Update failed',
+          description: message,
+        })
+      }
+    })
+  }
+
+  return (
+    <Button
+      type="button"
+      variant={optimisticImportant ? 'default' : 'ghost'}
+      size="sm"
+      className={optimisticImportant ? 'bg-amber-500 text-white hover:bg-amber-600' : 'text-muted-foreground'}
+      onClick={handleToggle}
+      disabled={isPending}
+    >
+      {isPending ? (
+        <Loader2 className="mr-1 h-4 w-4 animate-spin" aria-hidden="true" />
+      ) : (
+        <Star className={`mr-1 h-4 w-4 ${optimisticImportant ? 'fill-current' : ''}`} aria-hidden="true" />
+      )}
+      <span>{optimisticImportant ? 'Important' : 'Mark important'}</span>
+    </Button>
+  )
+}

--- a/src/components/admin/admin-user-notes-form.tsx
+++ b/src/components/admin/admin-user-notes-form.tsx
@@ -1,0 +1,158 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { z } from 'zod'
+
+import { CardDescription } from '@/components/ui/card'
+import { Switch } from '@/components/ui/switch'
+import { Label } from '@/components/ui/label'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { Button } from '@/components/ui/button'
+import { Loader2, Star } from 'lucide-react'
+import { useToast } from '@/components/ui/use-toast'
+
+const createNoteSchema = z.object({
+  subject: z.string().min(1, 'Subject is required').max(200, 'Subject is too long'),
+  note: z.string().min(1, 'Note body is required'),
+  important: z.boolean().optional(),
+})
+
+type AdminUserNotesFormProps = {
+  userId: string
+}
+
+export function AdminUserNotesForm({ userId }: AdminUserNotesFormProps) {
+  const router = useRouter()
+  const { toast } = useToast()
+
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [formState, setFormState] = useState({
+    important: false,
+    subject: '',
+    note: '',
+  })
+  const [error, setError] = useState<string | null>(null)
+
+  const handleChange = (field: 'important' | 'subject' | 'note', value: boolean | string) => {
+    setFormState((prev) => ({
+      ...prev,
+      [field]: value,
+    }))
+    setError(null)
+  }
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    if (isSubmitting) return
+
+    const parsed = createNoteSchema.safeParse(formState)
+
+    if (!parsed.success) {
+      setError(parsed.error.errors[0]?.message ?? 'Please complete all required fields')
+      return
+    }
+
+    setIsSubmitting(true)
+
+    try {
+      const response = await fetch(`/api/admin/users/${userId}/notes`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(parsed.data),
+      })
+
+      if (!response.ok) {
+        const payload = await response.json().catch(() => ({}))
+        const message = payload.error ?? 'Unable to save note'
+        throw new Error(message)
+      }
+
+      setFormState({ important: false, subject: '', note: '' })
+      toast({
+        title: 'Note saved',
+        description: 'The note has been recorded for this customer.',
+      })
+      router.refresh()
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unable to save note'
+      setError(message)
+      toast({
+        variant: 'destructive',
+        title: 'Could not save note',
+        description: message,
+      })
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <CardDescription className="text-sm text-muted-foreground">
+        Notes are internal only and cannot be edited after saving. Use the important toggle to flag standout
+        information for support teammates.
+      </CardDescription>
+
+      {error ? (
+        <p className="rounded-md border border-destructive/50 bg-destructive/5 px-3 py-2 text-sm text-destructive">
+          {error}
+        </p>
+      ) : null}
+
+      <div className="flex items-center justify-between rounded-md border border-border/60 bg-muted/40 px-3 py-2">
+        <div className="flex flex-col">
+          <Label htmlFor="note-important" className="text-sm font-medium">
+            Mark note as important
+          </Label>
+          <p className="text-xs text-muted-foreground">Important notes are pinned to the top of the customer history.</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Star
+            className={`h-4 w-4 ${formState.important ? 'fill-amber-500 text-amber-500' : 'text-muted-foreground'}`}
+            aria-hidden="true"
+          />
+          <Switch
+            id="note-important"
+            checked={formState.important}
+            onCheckedChange={(checked) => handleChange('important', checked)}
+            disabled={isSubmitting}
+          />
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="note-subject">Subject</Label>
+        <Input
+          id="note-subject"
+          value={formState.subject}
+          onChange={(event) => handleChange('subject', event.target.value)}
+          placeholder="Short summary"
+          maxLength={200}
+          disabled={isSubmitting}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="note-body">Note</Label>
+        <Textarea
+          id="note-body"
+          value={formState.note}
+          onChange={(event) => handleChange('note', event.target.value)}
+          placeholder="Document important interactions, escalations, or context for support."
+          rows={5}
+          disabled={isSubmitting}
+        />
+      </div>
+
+      <Button type="submit" disabled={isSubmitting} className="inline-flex items-center gap-2">
+        {isSubmitting ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : null}
+        {isSubmitting ? 'Saving note' : 'Save note'}
+      </Button>
+    </form>
+  )
+}

--- a/src/components/admin/admin-user-notes-table.tsx
+++ b/src/components/admin/admin-user-notes-table.tsx
@@ -1,0 +1,91 @@
+import { format } from 'date-fns'
+import { AdminNoteImportantToggle } from '@/components/admin/admin-note-important-toggle'
+import { Badge } from '@/components/ui/badge'
+
+export type AdminUserNoteRow = {
+  id: string
+  subject: string
+  note: string
+  important: boolean
+  createdAt: Date
+  authorName: string
+  authorEmail?: string | null
+}
+
+type AdminUserNotesTableProps = {
+  userId: string
+  notes: AdminUserNoteRow[]
+}
+
+export function AdminUserNotesTable({ userId, notes }: AdminUserNotesTableProps) {
+  if (!notes.length) {
+    return (
+      <div className="rounded-md border border-dashed border-border/60 bg-muted/30 px-4 py-10 text-center text-sm text-muted-foreground">
+        There are no notes for this customer yet. Save a note above to document important context for the team.
+      </div>
+    )
+  }
+
+  return (
+    <div className="overflow-hidden rounded-md border">
+      <table className="min-w-full divide-y divide-border">
+        <thead className="bg-muted/60">
+          <tr>
+            <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Subject &amp; note
+            </th>
+            <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Created
+            </th>
+            <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Created by
+            </th>
+            <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Important
+            </th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-border/60 bg-white">
+          {notes.map((note) => {
+            const createdLabel = format(note.createdAt, 'MMM d, yyyy p')
+            const [noteBody, ...history] = note.note.split('\n-----\n')
+
+            return (
+              <tr
+                key={note.id}
+                className={note.important ? 'bg-amber-50/70' : undefined}
+              >
+                <td className="align-top px-4 py-4 text-sm">
+                  <div className="flex flex-col gap-2">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <p className="font-semibold text-foreground">{note.subject}</p>
+                      {note.important ? <Badge variant="secondary">Important</Badge> : null}
+                    </div>
+                    <div className="whitespace-pre-wrap text-sm leading-relaxed text-muted-foreground">
+                      {noteBody}
+                      {history.length ? (
+                        <details className="mt-3 text-xs">
+                          <summary className="cursor-pointer font-medium text-foreground">View quoted history</summary>
+                          <div className="mt-2 whitespace-pre-wrap text-muted-foreground">
+                            {history.join('\n-----\n')}
+                          </div>
+                        </details>
+                      ) : null}
+                    </div>
+                  </div>
+                </td>
+                <td className="align-top px-4 py-4 text-sm text-muted-foreground">{createdLabel}</td>
+                <td className="align-top px-4 py-4 text-sm text-muted-foreground">
+                  {note.authorName || note.authorEmail || 'Support user'}
+                </td>
+                <td className="align-top px-4 py-4 text-sm text-muted-foreground">
+                  <AdminNoteImportantToggle userId={userId} noteId={note.id} important={note.important} />
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/src/components/dashboard-nav.tsx
+++ b/src/components/dashboard-nav.tsx
@@ -12,6 +12,7 @@ const navigation = [
   { name: 'Song Database', href: '/dashboard/songs' },
   { name: 'Requests', href: '/dashboard/requests' },
   { name: 'Billing', href: '/dashboard/billing' },
+  { name: 'Support', href: '/dashboard/support' },
   { name: 'Settings', href: '/dashboard/settings' },
 ]
 

--- a/src/components/support/support-attachment-link.tsx
+++ b/src/components/support/support-attachment-link.tsx
@@ -1,0 +1,58 @@
+import Link from 'next/link'
+import { Paperclip, ImageIcon, VideoIcon, FileText } from 'lucide-react'
+
+type Attachment = {
+  id: string
+  fileName: string
+  mimeType: string | null
+  byteSize: bigint | number | null
+  storageUrl: string
+}
+
+type SupportAttachmentLinkProps = {
+  attachment: Attachment
+}
+
+function formatFileSize(bytes: number | null): string {
+  if (!bytes || Number.isNaN(bytes)) return ''
+
+  const units = ['B', 'KB', 'MB', 'GB']
+  let size = bytes
+  let unitIndex = 0
+
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024
+    unitIndex += 1
+  }
+
+  return `${size.toFixed(size < 10 && unitIndex > 0 ? 1 : 0)} ${units[unitIndex]}`
+}
+
+function iconForMime(mimeType: string | null) {
+  if (!mimeType) return Paperclip
+
+  if (mimeType.startsWith('image/')) return ImageIcon
+  if (mimeType.startsWith('video/')) return VideoIcon
+
+  return FileText
+}
+
+export function SupportAttachmentLink({ attachment }: SupportAttachmentLinkProps) {
+  const Icon = iconForMime(attachment.mimeType)
+  const fileSize = formatFileSize(typeof attachment.byteSize === 'bigint' ? Number(attachment.byteSize) : attachment.byteSize ?? null)
+
+  return (
+    <Link
+      href={attachment.storageUrl}
+      className="flex items-center gap-2 rounded-md border border-border/60 bg-muted/50 px-3 py-2 text-sm text-muted-foreground transition-colors hover:border-primary hover:text-foreground"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      <Icon className="h-4 w-4" aria-hidden="true" />
+      <span className="truncate" title={attachment.fileName}>
+        {attachment.fileName}
+      </span>
+      {fileSize ? <span className="ml-auto text-xs uppercase tracking-wide">{fileSize}</span> : null}
+    </Link>
+  )
+}

--- a/src/components/support/support-ticket-create-form.tsx
+++ b/src/components/support/support-ticket-create-form.tsx
@@ -1,0 +1,210 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { z } from 'zod'
+import { Loader2, Paperclip } from 'lucide-react'
+
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { Label } from '@/components/ui/label'
+import { Button } from '@/components/ui/button'
+import { useToast } from '@/components/ui/use-toast'
+
+const createTicketSchema = z.object({
+  subject: z.string().min(5, 'Please include a short, descriptive subject line.'),
+  description: z.string().min(10, 'Add details so our team can assist quickly.'),
+  priority: z.enum(['low', 'normal', 'high', 'urgent']).default('normal'),
+  category: z.string().optional(),
+})
+
+const MAX_ATTACHMENTS = 5
+const MAX_ATTACHMENT_SIZE_BYTES = 10 * 1024 * 1024
+
+type SupportTicketCreateFormProps = {
+  defaultPriority?: 'low' | 'normal' | 'high' | 'urgent'
+}
+
+export function SupportTicketCreateForm({ defaultPriority = 'normal' }: SupportTicketCreateFormProps) {
+  const router = useRouter()
+  const { toast } = useToast()
+
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [attachments, setAttachments] = useState<File[]>([])
+  const [formState, setFormState] = useState({
+    subject: '',
+    description: '',
+    priority: defaultPriority,
+    category: '',
+  })
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(event.target.files ?? [])
+
+    if (files.length > MAX_ATTACHMENTS) {
+      setError(`You can attach up to ${MAX_ATTACHMENTS} files per ticket.`)
+      return
+    }
+
+    const oversize = files.find((file) => file.size > MAX_ATTACHMENT_SIZE_BYTES)
+    if (oversize) {
+      setError('Attachments must be 10MB or smaller.')
+      return
+    }
+
+    setAttachments(files)
+    setError(null)
+  }
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    if (isSubmitting) return
+
+    const parsed = createTicketSchema.safeParse(formState)
+    if (!parsed.success) {
+      setError(parsed.error.errors[0]?.message ?? 'Check the form and try again.')
+      return
+    }
+
+    setIsSubmitting(true)
+    setError(null)
+
+    try {
+      const formData = new FormData()
+      formData.append('subject', parsed.data.subject)
+      formData.append('description', parsed.data.description)
+      formData.append('priority', parsed.data.priority)
+      if (parsed.data.category) {
+        formData.append('category', parsed.data.category)
+      }
+
+      attachments.forEach((file) => {
+        formData.append('attachments', file)
+      })
+
+      const response = await fetch('/api/support/tickets', {
+        method: 'POST',
+        body: formData,
+      })
+
+      if (!response.ok) {
+        const payload = await response.json().catch(() => ({}))
+        throw new Error(payload.error ?? 'Unable to create ticket')
+      }
+
+      const payload = await response.json()
+
+      toast({
+        title: 'Support request submitted',
+        description: 'Our support team has been notified and will follow up shortly.',
+      })
+
+      setFormState({ subject: '', description: '', priority: defaultPriority, category: '' })
+      setAttachments([])
+      router.push(`/dashboard/support/${payload.id}`)
+      router.refresh()
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unable to create ticket'
+      setError(message)
+      toast({
+        variant: 'destructive',
+        title: 'Could not create ticket',
+        description: message,
+      })
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      {error ? (
+        <p className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">{error}</p>
+      ) : null}
+
+      <div className="space-y-2">
+        <Label htmlFor="ticket-subject">Subject</Label>
+        <Input
+          id="ticket-subject"
+          value={formState.subject}
+          onChange={(event) => setFormState((prev) => ({ ...prev, subject: event.target.value }))}
+          placeholder="Brief summary"
+          disabled={isSubmitting}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="ticket-category">Category (optional)</Label>
+        <Input
+          id="ticket-category"
+          value={formState.category}
+          onChange={(event) => setFormState((prev) => ({ ...prev, category: event.target.value }))}
+          placeholder="Billing, account, venue, etc."
+          disabled={isSubmitting}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="ticket-priority">Priority</Label>
+        <select
+          id="ticket-priority"
+          value={formState.priority}
+          onChange={(event) =>
+            setFormState((prev) => ({ ...prev, priority: event.target.value as 'low' | 'normal' | 'high' | 'urgent' }))
+          }
+          className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+          disabled={isSubmitting}
+        >
+          <option value="low">Low</option>
+          <option value="normal">Normal</option>
+          <option value="high">High</option>
+          <option value="urgent">Urgent</option>
+        </select>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="ticket-description">Describe your request</Label>
+        <Textarea
+          id="ticket-description"
+          value={formState.description}
+          onChange={(event) => setFormState((prev) => ({ ...prev, description: event.target.value }))}
+          rows={6}
+          placeholder="Share as much detail as you can so our support team can help quickly."
+          disabled={isSubmitting}
+        />
+        <p className="text-xs text-muted-foreground">Be sure to include venue names, dates, or error messages if relevant.</p>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="ticket-attachments" className="flex items-center gap-2 text-sm font-medium">
+          <Paperclip className="h-4 w-4" aria-hidden="true" /> Attachments (optional)
+        </Label>
+        <Input
+          id="ticket-attachments"
+          type="file"
+          multiple
+          onChange={handleFileChange}
+          disabled={isSubmitting}
+          accept="image/*,video/*,.pdf,.doc,.docx,.xls,.xlsx,.ppt,.pptx,.txt,.rtf"
+        />
+        <p className="text-xs text-muted-foreground">
+          Attach up to {MAX_ATTACHMENTS} files (images, videos, or documents). Each file must be 10MB or smaller.
+        </p>
+        {attachments.length ? (
+          <ul className="text-xs text-muted-foreground">
+            {attachments.map((file) => (
+              <li key={file.name}>{file.name}</li>
+            ))}
+          </ul>
+        ) : null}
+      </div>
+
+      <Button type="submit" disabled={isSubmitting} className="inline-flex items-center gap-2">
+        {isSubmitting ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : null}
+        {isSubmitting ? 'Submitting request' : 'Submit support request'}
+      </Button>
+    </form>
+  )
+}

--- a/src/components/support/support-ticket-list.tsx
+++ b/src/components/support/support-ticket-list.tsx
@@ -1,0 +1,129 @@
+import Link from 'next/link'
+import { formatDistanceToNow } from 'date-fns'
+import { MessageCircle, ArrowUpRight } from 'lucide-react'
+
+import {
+  SupportTicketStatusBadge,
+  type TicketStatus,
+} from '@/components/support/support-ticket-status-badge'
+import {
+  SupportTicketPriorityBadge,
+  type TicketPriority,
+} from '@/components/support/support-ticket-priority-badge'
+import { Badge } from '@/components/ui/badge'
+
+type TicketListItem = {
+  id: string
+  subject: string
+  status: TicketStatus
+  priority: TicketPriority
+  createdAt: Date
+  updatedAt: Date
+  messageCount: number
+  lastMessageAt?: Date | null
+  lastMessageAuthorId?: string | null
+  assigneeName?: string | null
+}
+
+type SupportTicketListProps = {
+  tickets: TicketListItem[]
+  currentUserId: string
+}
+
+export function SupportTicketList({ tickets, currentUserId }: SupportTicketListProps) {
+  if (!tickets.length) {
+    return (
+      <div className="rounded-md border border-dashed border-border/60 bg-muted/20 px-4 py-12 text-center text-sm text-muted-foreground">
+        You haven’t created any support tickets yet. Submit a request using the form above to get started.
+      </div>
+    )
+  }
+
+  return (
+    <div className="overflow-hidden rounded-md border">
+      <table className="min-w-full divide-y divide-border">
+        <thead className="bg-muted/60">
+          <tr>
+            <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Subject
+            </th>
+            <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Status
+            </th>
+            <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Priority
+            </th>
+            <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Last update
+            </th>
+            <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Messages
+            </th>
+            <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Assignee
+            </th>
+            <th className="px-4 py-3 text-xs" aria-hidden />
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-border/60 bg-white">
+          {tickets.map((ticket) => {
+            const hasNewMessage =
+              ticket.lastMessageAuthorId && ticket.lastMessageAuthorId !== currentUserId
+            const lastUpdateLabel = formatDistanceToNow(ticket.updatedAt, { addSuffix: true })
+            const messageLabel = `${ticket.messageCount} ${ticket.messageCount === 1 ? 'message' : 'messages'}`
+
+            return (
+              <tr key={ticket.id} className="text-sm">
+                <td className="max-w-[320px] px-4 py-4">
+                  <div className="flex flex-col gap-1">
+                    <Link
+                      href={`/dashboard/support/${ticket.id}`}
+                      className="font-semibold text-foreground hover:text-primary"
+                    >
+                      {ticket.subject}
+                    </Link>
+                    <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                      <span>Opened {formatDistanceToNow(ticket.createdAt, { addSuffix: true })}</span>
+                      {hasNewMessage ? (
+                        <Badge variant="destructive" className="uppercase tracking-wide">
+                          New response
+                        </Badge>
+                      ) : null}
+                    </div>
+                  </div>
+                </td>
+                <td className="px-4 py-4">
+                  <SupportTicketStatusBadge status={ticket.status} />
+                </td>
+                <td className="px-4 py-4">
+                  <SupportTicketPriorityBadge priority={ticket.priority} />
+                </td>
+                <td className="px-4 py-4 text-sm text-muted-foreground">{lastUpdateLabel}</td>
+                <td className="px-4 py-4 text-sm text-muted-foreground">
+                  <div className="inline-flex items-center gap-1">
+                    <MessageCircle className="h-4 w-4" aria-hidden="true" />
+                    {messageLabel}
+                  </div>
+                </td>
+                <td className="px-4 py-4 text-sm text-muted-foreground">
+                  {ticket.assigneeName ? ticket.assigneeName : 'Unassigned'}
+                </td>
+                <td className="px-4 py-4 text-right">
+                  <Link
+                    href={`/dashboard/support/${ticket.id}`}
+                    className="inline-flex items-center gap-1 text-sm font-medium text-primary hover:underline"
+                  >
+                    View
+                    <ArrowUpRight className="h-4 w-4" aria-hidden="true" />
+                  </Link>
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+SupportTicketList.displayName = 'SupportTicketList'

--- a/src/components/support/support-ticket-message-thread.tsx
+++ b/src/components/support/support-ticket-message-thread.tsx
@@ -1,0 +1,95 @@
+import { format } from 'date-fns'
+
+import { Badge } from '@/components/ui/badge'
+import { SupportAttachmentLink } from '@/components/support/support-attachment-link'
+
+type ThreadAttachment = {
+  id: string
+  fileName: string
+  mimeType: string | null
+  byteSize: bigint | number | null
+  storageUrl: string
+}
+
+type ThreadMessage = {
+  id: string
+  body: string
+  createdAt: Date
+  author: {
+    id: string
+    name: string | null
+    email: string | null
+  }
+  attachments: ThreadAttachment[]
+}
+
+type SupportTicketMessageThreadProps = {
+  currentUserId: string
+  messages: ThreadMessage[]
+}
+
+export function SupportTicketMessageThread({ currentUserId, messages }: SupportTicketMessageThreadProps) {
+  if (!messages.length) {
+    return (
+      <div className="rounded-md border border-dashed border-border/60 bg-muted/20 px-4 py-12 text-center text-sm text-muted-foreground">
+        No public messages have been posted to this ticket yet.
+      </div>
+    )
+  }
+
+  return (
+    <ul className="space-y-4">
+      {messages.map((message) => {
+        const isRequester = message.author.id === currentUserId
+        const [primaryBody, ...history] = message.body.split('\n-----\n')
+        const authorLabel = isRequester
+          ? 'You'
+          : message.author.name || message.author.email || 'Support team'
+        const timestamp = format(message.createdAt, 'MMM d, yyyy p')
+
+        return (
+          <li key={message.id}>
+            <article
+              className={`flex flex-col gap-3 rounded-lg border px-5 py-4 ${
+                isRequester ? 'border-primary/60 bg-primary/5' : 'border-border/70 bg-white'
+              }`}
+            >
+              <header className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+                <div className="flex items-center gap-2 text-sm font-medium text-foreground">
+                  {authorLabel}
+                  <Badge variant="outline" className="text-xs uppercase tracking-wide">
+                    {isRequester ? 'Customer' : 'Support'}
+                  </Badge>
+                </div>
+                <time className="text-xs uppercase tracking-wide text-muted-foreground" dateTime={message.createdAt.toISOString()}>
+                  {timestamp}
+                </time>
+              </header>
+
+              <div className="space-y-3 text-sm leading-relaxed text-foreground">
+                <div className="whitespace-pre-line text-muted-foreground">{primaryBody.trim() || '—'}</div>
+                {history.length ? (
+                  <details className="text-xs text-muted-foreground">
+                    <summary className="cursor-pointer font-medium text-foreground">Quoted conversation</summary>
+                    <div className="mt-2 whitespace-pre-line">{history.join('\n-----\n')}</div>
+                  </details>
+                ) : null}
+              </div>
+
+              {message.attachments.length ? (
+                <div className="flex flex-col gap-2">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Attachments</p>
+                  <div className="flex flex-col gap-2">
+                    {message.attachments.map((attachment) => (
+                      <SupportAttachmentLink key={attachment.id} attachment={attachment} />
+                    ))}
+                  </div>
+                </div>
+              ) : null}
+            </article>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}

--- a/src/components/support/support-ticket-priority-badge.tsx
+++ b/src/components/support/support-ticket-priority-badge.tsx
@@ -1,0 +1,40 @@
+import { Badge } from '@/components/ui/badge'
+import { cn } from '@/lib/utils'
+
+export type TicketPriority = 'low' | 'normal' | 'high' | 'urgent'
+
+const PRIORITY_STYLES: Record<
+  TicketPriority,
+  { label: string; className: string }
+> = {
+  low: {
+    label: 'Low',
+    className: 'bg-slate-100 text-slate-800 hover:bg-slate-100',
+  },
+  normal: {
+    label: 'Normal',
+    className: 'bg-blue-100 text-blue-900 hover:bg-blue-100',
+  },
+  high: {
+    label: 'High',
+    className: 'bg-amber-100 text-amber-900 hover:bg-amber-100',
+  },
+  urgent: {
+    label: 'Urgent',
+    className: 'bg-destructive text-destructive-foreground hover:bg-destructive',
+  },
+}
+
+type SupportTicketPriorityBadgeProps = {
+  priority: TicketPriority
+}
+
+export function SupportTicketPriorityBadge({ priority }: SupportTicketPriorityBadgeProps) {
+  const style = PRIORITY_STYLES[priority]
+
+  return (
+    <Badge variant="secondary" className={cn('capitalize', style.className)}>
+      {style.label}
+    </Badge>
+  )
+}

--- a/src/components/support/support-ticket-reply-form.tsx
+++ b/src/components/support/support-ticket-reply-form.tsx
@@ -1,0 +1,146 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Loader2, Paperclip } from 'lucide-react'
+
+import { Textarea } from '@/components/ui/textarea'
+import { Label } from '@/components/ui/label'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { useToast } from '@/components/ui/use-toast'
+
+const MAX_ATTACHMENTS = 5
+const MAX_ATTACHMENT_SIZE_BYTES = 10 * 1024 * 1024
+
+type SupportTicketReplyFormProps = {
+  ticketId: string
+  disabled?: boolean
+}
+
+export function SupportTicketReplyForm({ ticketId, disabled = false }: SupportTicketReplyFormProps) {
+  const router = useRouter()
+  const { toast } = useToast()
+
+  const [message, setMessage] = useState('')
+  const [attachments, setAttachments] = useState<File[]>([])
+  const [error, setError] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(event.target.files ?? [])
+
+    if (files.length > MAX_ATTACHMENTS) {
+      setError(`You can attach up to ${MAX_ATTACHMENTS} files per reply.`)
+      return
+    }
+
+    const oversize = files.find((file) => file.size > MAX_ATTACHMENT_SIZE_BYTES)
+    if (oversize) {
+      setError('Attachments must be 10MB or smaller.')
+      return
+    }
+
+    setAttachments(files)
+    setError(null)
+  }
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    if (isSubmitting || disabled) return
+
+    if (!message.trim()) {
+      setError('Add a message before sending your reply.')
+      return
+    }
+
+    setIsSubmitting(true)
+    setError(null)
+
+    try {
+      const formData = new FormData()
+      formData.append('body', message.trim())
+      attachments.forEach((file) => formData.append('attachments', file))
+
+      const response = await fetch(`/api/support/tickets/${ticketId}/messages`, {
+        method: 'POST',
+        body: formData,
+      })
+
+      if (!response.ok) {
+        const payload = await response.json().catch(() => ({}))
+        throw new Error(payload.error ?? 'Unable to send reply')
+      }
+
+      toast({
+        title: 'Message sent',
+        description: 'Your update has been shared with our support team.',
+      })
+
+      setMessage('')
+      setAttachments([])
+      router.refresh()
+    } catch (err) {
+      const messageText = err instanceof Error ? err.message : 'Unable to send reply'
+      setError(messageText)
+      toast({
+        variant: 'destructive',
+        title: 'Could not send reply',
+        description: messageText,
+      })
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      {error ? (
+        <p className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">{error}</p>
+      ) : null}
+
+      <div className="space-y-2">
+        <Label htmlFor="ticket-reply">Reply</Label>
+        <Textarea
+          id="ticket-reply"
+          value={message}
+          onChange={(event) => setMessage(event.target.value)}
+          rows={6}
+          placeholder="Share an update or respond to the support team."
+          disabled={isSubmitting || disabled}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="ticket-reply-attachments" className="flex items-center gap-2 text-sm font-medium">
+          <Paperclip className="h-4 w-4" aria-hidden="true" /> Attachments (optional)
+        </Label>
+        <Input
+          id="ticket-reply-attachments"
+          type="file"
+          multiple
+          onChange={handleFileChange}
+          disabled={isSubmitting || disabled}
+          accept="image/*,video/*,.pdf,.doc,.docx,.xls,.xlsx,.ppt,.pptx,.txt,.rtf"
+        />
+        <p className="text-xs text-muted-foreground">
+          Attach up to {MAX_ATTACHMENTS} files. Each must be 10MB or smaller. Internal notes entered by support will remain
+          private.
+        </p>
+        {attachments.length ? (
+          <ul className="text-xs text-muted-foreground">
+            {attachments.map((file) => (
+              <li key={file.name}>{file.name}</li>
+            ))}
+          </ul>
+        ) : null}
+      </div>
+
+      <Button type="submit" disabled={isSubmitting || disabled} className="inline-flex items-center gap-2">
+        {isSubmitting ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : null}
+        {isSubmitting ? 'Sending reply' : 'Send reply'}
+      </Button>
+    </form>
+  )
+}

--- a/src/components/support/support-ticket-status-badge.tsx
+++ b/src/components/support/support-ticket-status-badge.tsx
@@ -1,0 +1,41 @@
+import { Badge } from '@/components/ui/badge'
+import { cn } from '@/lib/utils'
+
+export type TicketStatus = 'open' | 'pending_customer' | 'pending_support' | 'resolved' | 'closed'
+
+const STATUS_STYLES: Record<
+  TicketStatus,
+  { label: string; variant: 'default' | 'secondary' | 'outline' | 'destructive'; className?: string }
+> = {
+  open: { label: 'Open', variant: 'default' },
+  pending_customer: {
+    label: 'Waiting on you',
+    variant: 'secondary',
+    className: 'bg-amber-100 text-amber-900 hover:bg-amber-100',
+  },
+  pending_support: {
+    label: 'Waiting on support',
+    variant: 'secondary',
+    className: 'bg-blue-100 text-blue-900 hover:bg-blue-100',
+  },
+  resolved: {
+    label: 'Resolved',
+    variant: 'secondary',
+    className: 'bg-emerald-100 text-emerald-900 hover:bg-emerald-100',
+  },
+  closed: { label: 'Closed', variant: 'outline', className: 'text-muted-foreground' },
+}
+
+type SupportTicketStatusBadgeProps = {
+  status: TicketStatus
+}
+
+export function SupportTicketStatusBadge({ status }: SupportTicketStatusBadgeProps) {
+  const style = STATUS_STYLES[status]
+
+  return (
+    <Badge variant={style.variant} className={cn('capitalize', style.className)}>
+      {style.label}
+    </Badge>
+  )
+}

--- a/src/lib/support-attachments.ts
+++ b/src/lib/support-attachments.ts
@@ -1,0 +1,86 @@
+import { promises as fs } from 'fs'
+import path from 'path'
+import { randomUUID } from 'crypto'
+
+const MAX_ATTACHMENT_SIZE_BYTES = 10 * 1024 * 1024 // 10 MB
+const ALLOWED_MIME_PREFIXES = ['image/', 'video/']
+const ALLOWED_MIME_TYPES = new Set([
+  'application/pdf',
+  'application/msword',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  'application/vnd.ms-excel',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  'application/vnd.ms-powerpoint',
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  'text/plain',
+])
+const ALLOWED_EXTENSIONS = new Set([
+  '.pdf',
+  '.doc',
+  '.docx',
+  '.xls',
+  '.xlsx',
+  '.ppt',
+  '.pptx',
+  '.txt',
+  '.rtf',
+  '.jpg',
+  '.jpeg',
+  '.png',
+  '.gif',
+  '.webp',
+  '.heic',
+  '.mp4',
+  '.mov',
+  '.mkv',
+  '.avi',
+])
+
+export type SavedSupportAttachment = {
+  fileName: string
+  mimeType?: string
+  byteSize: number
+  storageUrl: string
+}
+
+export class AttachmentValidationError extends Error {}
+
+function ensureAttachmentType(file: File) {
+  const mimeType = file.type || undefined
+  const extension = path.extname(file.name || '').toLowerCase()
+
+  const isAllowedMimePrefix = mimeType ? ALLOWED_MIME_PREFIXES.some((prefix) => mimeType.startsWith(prefix)) : false
+  const isAllowedMimeType = mimeType ? ALLOWED_MIME_TYPES.has(mimeType) : false
+  const isAllowedExtension = extension ? ALLOWED_EXTENSIONS.has(extension) : false
+
+  if (!(isAllowedMimePrefix || isAllowedMimeType || isAllowedExtension)) {
+    throw new AttachmentValidationError('Unsupported attachment type. Upload images, videos, or document files only.')
+  }
+}
+
+export async function persistSupportAttachment(ticketId: string, file: File): Promise<SavedSupportAttachment> {
+  if (file.size > MAX_ATTACHMENT_SIZE_BYTES) {
+    throw new AttachmentValidationError('Attachments must be 10MB or smaller.')
+  }
+
+  ensureAttachmentType(file)
+
+  const buffer = Buffer.from(await file.arrayBuffer())
+  const extension = path.extname(file.name || '').toLowerCase() || ''
+  const safeExtension = extension.replace(/[^a-z0-9.]/g, '')
+  const storedFileName = `${randomUUID()}${safeExtension}`
+  const relativeDir = path.join('uploads', 'support', ticketId)
+  const absoluteDir = path.join(process.cwd(), 'public', relativeDir)
+
+  await fs.mkdir(absoluteDir, { recursive: true })
+
+  const absolutePath = path.join(absoluteDir, storedFileName)
+  await fs.writeFile(absolutePath, buffer)
+
+  return {
+    fileName: file.name || storedFileName,
+    mimeType: file.type || undefined,
+    byteSize: buffer.length,
+    storageUrl: `/${relativeDir.replace(/\\/g, '/')}/${storedFileName}`,
+  }
+}


### PR DESCRIPTION
## Summary
- add an admin-only notes workspace with create form, sortable table, and summary card on the customer profile page
- expose admin APIs for writing and flagging customer notes and wire them into the UI
- build the customer support centre with ticket stats, creation form, detail view, threaded replies with attachments, and supporting APIs/utilities

## Testing
- npm run type-check *(fails: existing project TypeScript errors; see output)*

------
https://chatgpt.com/codex/tasks/task_e_68e5f0cf7b58833084042f5160243a53